### PR TITLE
feat(adguard): improve adguard setup with default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ SSH into your OpenWRT router and run:
 wget -O- https://raw.githubusercontent.com/raydak-labs/travo/main/scripts/install.sh | sh
 ```
 
-This installs the Travel GUI on port 80, AdGuard Home on port 3000 (DNS on 53),
+This installs Travo on port 80, AdGuard Home on port 3000 (DNS on 5353 via dnsmasq forwarding),
 and moves LuCI to port 8080. See [docs/deployment.md](docs/deployment.md) for
 all options and manual install instructions.
+
+> **Default AdGuard credentials:** `admin` / `password` — change immediately via
+> **Settings → AdGuard Password** in the Travo UI.
 
 ## General
 

--- a/backend/internal/api/adguard_handlers.go
+++ b/backend/internal/api/adguard_handlers.go
@@ -74,6 +74,29 @@ func GetAdGuardConfigHandler(adguard *services.AdGuardService) fiber.Handler {
 	}
 }
 
+// SetAdGuardPasswordHandler handles PUT /api/v1/adguard/password.
+func SetAdGuardPasswordHandler(adguard *services.AdGuardService) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		var body struct {
+			Username string `json:"username"`
+			Password string `json:"password"`
+		}
+		if err := c.BodyParser(&body); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		}
+		if body.Password == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "password is required"})
+		}
+		if body.Username == "" {
+			body.Username = "admin"
+		}
+		if err := adguard.SetPassword(body.Username, body.Password); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		}
+		return c.JSON(fiber.Map{"status": "ok"})
+	}
+}
+
 // SetAdGuardConfigHandler handles PUT /api/v1/adguard/config.
 func SetAdGuardConfigHandler(adguard *services.AdGuardService) fiber.Handler {
 	return func(c *fiber.Ctx) error {

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -182,6 +182,7 @@ func SetupRoutes(app *fiber.App, deps *Dependencies) {
 	v1.Put("/adguard/dns", SetAdGuardDNSHandler(deps.AdGuard))
 	v1.Get("/adguard/config", GetAdGuardConfigHandler(deps.AdGuard))
 	v1.Put("/adguard/config", SetAdGuardConfigHandler(deps.AdGuard))
+	v1.Put("/adguard/password", SetAdGuardPasswordHandler(deps.AdGuard))
 
 	// Data usage tracking (requires vnstat)
 	v1.Get("/network/data-usage", GetDataUsageHandler(deps.DataUsage))

--- a/backend/internal/services/adguard_service.go
+++ b/backend/internal/services/adguard_service.go
@@ -12,16 +12,18 @@ import (
 	"time"
 
 	"github.com/openwrt-travel-gui/backend/internal/models"
+	"golang.org/x/crypto/bcrypt"
 	yaml "gopkg.in/yaml.v3"
 )
 
 const (
-	adguardBinary         = "/opt/AdGuardHome/AdGuardHome"
-	adguardInitd          = "/etc/init.d/adguardhome"
-	adguardAPIBaseDefault = "http://127.0.0.1:3000"
-	adguardDefaultDNSPort = 5353
-	adguardYAMLPathUCI    = "/etc/adguardhome/adguardhome.yaml"
-	adguardYAMLPathOpt    = "/opt/AdGuardHome/AdGuardHome.yaml"
+	adguardBinary          = "/opt/AdGuardHome/AdGuardHome"
+	adguardInitd           = "/etc/init.d/adguardhome"
+	adguardAPIBaseDefault  = "http://127.0.0.1:3000"
+	adguardDefaultDNSPort  = 5353
+	adguardYAMLPathUCI     = "/etc/adguardhome/adguardhome.yaml"
+	adguardYAMLPathOpt     = "/opt/AdGuardHome/AdGuardHome.yaml"
+	adguardBundledTemplate = "/etc/travo/adguardhome.yaml"
 )
 
 // AdGuardChecker abstracts filesystem/process checks for testability.
@@ -418,7 +420,15 @@ verbose: false
 func (s *AdGuardService) AutoConfigure() error {
 	if !s.checker.FileExists(adguardYAMLPathUCI) && !s.checker.FileExists(adguardYAMLPathOpt) {
 		_, _ = s.checker.RunCommand("mkdir", "-p", "/opt/AdGuardHome")
-		if err := s.checker.WriteFile(adguardYAMLPathOpt, []byte(defaultAdGuardConfig), 0600); err != nil {
+		// Prefer the bundled template shipped with the tarball; fall back to the
+		// embedded constant so AutoConfigure works in non-tarball environments too.
+		var configBytes []byte
+		if bundled, err := s.checker.ReadFile(adguardBundledTemplate); err == nil {
+			configBytes = bundled
+		} else {
+			configBytes = []byte(defaultAdGuardConfig)
+		}
+		if err := s.checker.WriteFile(adguardYAMLPathOpt, configBytes, 0600); err != nil {
 			return fmt.Errorf("writing default AdGuard config: %w", err)
 		}
 	}
@@ -465,4 +475,56 @@ func (s *AdGuardService) SetConfig(content string) error {
 	}
 	s.refreshEndpointsFromYAML()
 	return nil
+}
+
+// SetPassword hashes password with bcrypt (default cost) and writes it into the
+// AdGuard Home YAML config under the first matching user, then restarts the service.
+func (s *AdGuardService) SetPassword(username, password string) error {
+	if password == "" {
+		return fmt.Errorf("password must not be empty")
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return fmt.Errorf("hashing password: %w", err)
+	}
+
+	configStr, err := s.GetConfig()
+	if err != nil {
+		return fmt.Errorf("reading AdGuard config: %w", err)
+	}
+
+	// Unmarshal into a generic map so all unrecognised keys are preserved.
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal([]byte(configStr), &doc); err != nil {
+		return fmt.Errorf("parsing AdGuard config: %w", err)
+	}
+
+	users, _ := doc["users"].([]interface{})
+	updated := false
+	for _, u := range users {
+		m, ok := u.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if m["name"] == username {
+			m["password"] = string(hash)
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		// User not found — append a new entry.
+		users = append(users, map[string]interface{}{
+			"name":     username,
+			"password": string(hash),
+		})
+		doc["users"] = users
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("serialising AdGuard config: %w", err)
+	}
+	return s.SetConfig(string(out))
 }

--- a/frontend/src/hooks/use-services.ts
+++ b/frontend/src/hooks/use-services.ts
@@ -132,3 +132,16 @@ export function useSetAdGuardConfig() {
     },
   });
 }
+
+export function useChangeAdGuardPassword() {
+  return useMutation({
+    mutationFn: ({ username, password }: { username?: string; password: string }) =>
+      apiClient.put<{ status: string }>(API_ROUTES.adguard.password, { username, password }),
+    onSuccess: () => {
+      toast.success('AdGuard password updated');
+    },
+    onError: (error) => {
+      toast.error('Failed to update AdGuard password', { description: error.message });
+    },
+  });
+}

--- a/frontend/src/lib/schemas/system-forms.ts
+++ b/frontend/src/lib/schemas/system-forms.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 
+/** AdGuard Home password change (no current password required — admin-level). */
+export const changeAdGuardPasswordSchema = z
+  .object({
+    new_password: z.string().min(6, 'Password must be at least 6 characters'),
+    confirm_password: z.string().min(1, 'Confirm your new password'),
+  })
+  .refine((data) => data.new_password === data.confirm_password, {
+    message: 'Passwords do not match',
+    path: ['confirm_password'],
+  });
+
+export type ChangeAdGuardPasswordFormValues = z.infer<typeof changeAdGuardPasswordSchema>;
+
 /** System page — change admin password (API allows new password ≥ 6 chars). */
 export const changeAdminPasswordSchema = z
   .object({

--- a/frontend/src/pages/system/adguard-password-card.tsx
+++ b/frontend/src/pages/system/adguard-password-card.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { KeyRound } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useChangeAdGuardPassword } from '@/hooks/use-services';
+import { useServices } from '@/hooks/use-services';
+import {
+  changeAdGuardPasswordSchema,
+  type ChangeAdGuardPasswordFormValues,
+} from '@/lib/schemas/system-forms';
+
+export function AdGuardPasswordCard() {
+  const { data: services = [] } = useServices();
+  const adguardInstalled = services.some(
+    (s) => s.id === 'adguardhome' && s.state !== 'not_installed',
+  );
+
+  const changePasswordMutation = useChangeAdGuardPassword();
+  const [isEditing, setIsEditing] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ChangeAdGuardPasswordFormValues>({
+    resolver: zodResolver(changeAdGuardPasswordSchema),
+    defaultValues: { new_password: '', confirm_password: '' },
+    mode: 'onChange',
+  });
+
+  if (!adguardInstalled) return null;
+
+  const resetAndClose = () => {
+    reset({ new_password: '', confirm_password: '' });
+    setIsEditing(false);
+  };
+
+  const onSubmit = (data: ChangeAdGuardPasswordFormValues) => {
+    changePasswordMutation.mutate(
+      { password: data.new_password },
+      { onSuccess: resetAndClose },
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">AdGuard Password</CardTitle>
+        <KeyRound className="h-4 w-4 text-gray-500" />
+      </CardHeader>
+
+      <CardContent>
+        {!isEditing ? (
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Change the AdGuard Home admin password.
+            </p>
+            <Button size="sm" variant="outline" onClick={() => setIsEditing(true)}>
+              Change
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-3" noValidate>
+            <Input
+              type="password"
+              placeholder="New password (min 6 characters)"
+              autoComplete="new-password"
+              aria-invalid={!!errors.new_password}
+              aria-describedby={errors.new_password ? 'ag-pw-new-err' : undefined}
+              {...register('new_password')}
+            />
+            {errors.new_password ? (
+              <p id="ag-pw-new-err" className="text-sm text-red-500" role="alert">
+                {errors.new_password.message}
+              </p>
+            ) : null}
+            <Input
+              type="password"
+              placeholder="Confirm new password"
+              autoComplete="new-password"
+              aria-invalid={!!errors.confirm_password}
+              aria-describedby={errors.confirm_password ? 'ag-pw-confirm-err' : undefined}
+              {...register('confirm_password')}
+            />
+            {errors.confirm_password ? (
+              <p id="ag-pw-confirm-err" className="text-sm text-red-500" role="alert">
+                {errors.confirm_password.message}
+              </p>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="submit"
+                size="sm"
+                disabled={changePasswordMutation.isPending || isSubmitting}
+              >
+                {changePasswordMutation.isPending ? 'Saving…' : 'Save Password'}
+              </Button>
+              <Button type="button" size="sm" variant="outline" onClick={resetAndClose}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/system/system-page.tsx
+++ b/frontend/src/pages/system/system-page.tsx
@@ -10,6 +10,7 @@ import { SystemTimezoneCard } from './system-timezone-card';
 import { SystemBackupRestoreCard } from './system-backup-restore-card';
 import { SystemQuickLinksCard } from './system-quick-links-card';
 import { SystemPowerSection } from './system-power-section';
+import { AdGuardPasswordCard } from './adguard-password-card';
 
 export function SystemPage() {
   return (
@@ -24,6 +25,7 @@ export function SystemPage() {
           <SystemTimezoneCard />
           <NTPConfigCard />
           <ChangePasswordCard />
+          <AdGuardPasswordCard />
           <HardwareButtonsCard />
           <LEDControlCard />
           <AlertThresholdsCard />

--- a/packaging/adguard/AdGuardHome.yaml
+++ b/packaging/adguard/AdGuardHome.yaml
@@ -1,0 +1,193 @@
+http:
+  pprof:
+    port: 6060
+    enabled: false
+  address: 0.0.0.0:3000
+  session_ttl: 720h
+users:
+  - name: admin
+    password: $2a$10$Xn9ScJAC90tv4.03HUjbtOyG2ENRRRyw60waCVDamjuFbo3b6Vqsy
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ''
+language: ''
+theme: auto
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: 5353
+  anonymize_client_ip: false
+  ratelimit: 20
+  ratelimit_subnet_len_ipv4: 24
+  ratelimit_subnet_len_ipv6: 56
+  ratelimit_whitelist: []
+  refuse_any: true
+  upstream_dns:
+    - https://dns10.quad9.net/dns-query
+  upstream_dns_file: ''
+  bootstrap_dns:
+    - 9.9.9.10
+    - 149.112.112.10
+    - 2620:fe::10
+    - 2620:fe::fe:10
+  fallback_dns:
+    - tls://one.one.one.one
+  upstream_mode: load_balance
+  fastest_timeout: 1s
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+    - version.bind
+    - id.server
+    - hostname.bind
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+  cache_enabled: true
+  cache_size: 4194304
+  cache_ttl_min: 120
+  cache_ttl_max: 86400
+  cache_optimistic: true
+  cache_optimistic_answer_ttl: 30s
+  cache_optimistic_max_age: 12h
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: true
+  edns_client_subnet:
+    custom_ip: ''
+    enabled: false
+    use_custom: false
+  max_goroutines: 300
+  handle_ddr: true
+  ipset: []
+  ipset_file: ''
+  bootstrap_prefer_ipv6: false
+  upstream_timeout: 10s
+  private_networks: []
+  use_private_ptr_resolvers: true
+  local_ptr_upstreams: []
+  use_dns64: false
+  dns64_prefixes: []
+  serve_http3: false
+  use_http3_upstreams: false
+  serve_plain_dns: true
+  hostsfile_enabled: true
+  pending_requests:
+    enabled: true
+tls:
+  enabled: false
+  server_name: ''
+  force_https: false
+  port_https: 443
+  port_dns_over_tls: 853
+  port_dns_over_quic: 853
+  port_dnscrypt: 0
+  dnscrypt_config_file: ''
+  allow_unencrypted_doh: false
+  certificate_chain: ''
+  private_key: ''
+  certificate_path: ''
+  private_key_path: ''
+  strict_sni_check: false
+querylog:
+  dir_path: ''
+  ignored: []
+  interval: 2160h
+  size_memory: 1000
+  enabled: true
+  ignored_enabled: false
+  file_enabled: true
+statistics:
+  dir_path: ''
+  ignored: []
+  interval: 24h
+  enabled: true
+  ignored_enabled: false
+filters:
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+    id: 1
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
+    name: AdAway Default Blocklist
+    id: 2
+  - enabled: true
+    url: https://cdn.jsdelivr.net/gh/hagezi/dns-blocklists@latest/adblock/pro.txt
+    name: hagezi/dns-blocklist (pro)
+    id: 3
+whitelist_filters: []
+user_rules: []
+dhcp:
+  enabled: false
+  interface_name: ''
+  local_domain_name: lan
+  dhcpv4:
+    gateway_ip: ''
+    subnet_mask: ''
+    range_start: ''
+    range_end: ''
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ''
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+filtering:
+  blocking_ipv4: ''
+  blocking_ipv6: ''
+  blocked_services:
+    schedule:
+      time_zone: UTC
+    ids: []
+  protection_disabled_until: null
+  safe_search:
+    enabled: false
+    bing: true
+    duckduckgo: true
+    ecosia: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+  blocking_mode: default
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites: []
+  safe_fs_patterns:
+    - /var/lib/adguardhome/userfilters/*
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  filters_update_interval: 24
+  blocked_response_ttl: 10
+  filtering_enabled: true
+  rewrites_enabled: true
+  parental_enabled: false
+  safebrowsing_enabled: false
+  protection_enabled: true
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: true
+    dhcp: true
+    hosts: true
+  persistent: []
+log:
+  enabled: true
+  file: ''
+  max_backups: 0
+  max_size: 100
+  max_age: 3
+  compress: false
+  local_time: false
+  verbose: false
+os:
+  group: ''
+  user: ''
+  rlimit_nofile: 0
+schema_version: 33

--- a/scripts/install-adguard.sh
+++ b/scripts/install-adguard.sh
@@ -100,189 +100,35 @@ write_config() {
     fi
 
     log "Writing initial config to ${ADGUARD_CONF} ..."
-    cat > "$ADGUARD_CONF" <<'YAML'
-http:
-  pprof:
-    port: 6060
-    enabled: false
-  address: 0.0.0.0:3000
-  session_ttl: 720h
-users: []
-auth_attempts: 5
-block_auth_min: 15
-http_proxy: ""
-language: ""
-theme: auto
-dns:
-  bind_hosts:
-    - 0.0.0.0
-  port: 53
-  anonymize_client_ip: false
-  ratelimit: 0
-  ratelimit_subnet_len_ipv4: 24
-  ratelimit_subnet_len_ipv6: 56
-  ratelimit_whitelist: []
-  refuse_any: true
-  upstream_dns:
-    - https://dns.cloudflare.com/dns-query
-    - https://dns.google/dns-query
-  upstream_dns_file: ""
-  bootstrap_dns:
-    - 1.1.1.1
-    - 8.8.8.8
-  fallback_dns: []
-  upstream_mode: load_balance
-  fastest_timeout: 1s
-  allowed_clients: []
-  disallowed_clients: []
-  blocked_hosts:
-    - version.bind
-    - id.server
-    - hostname.bind
-  trusted_proxies:
-    - 127.0.0.0/8
-    - ::1/128
-  cache_size: 4194304
-  cache_ttl_min: 0
-  cache_ttl_max: 0
-  cache_optimistic: true
-  bogus_nxdomain: []
-  aaaa_disabled: false
-  enable_dnssec: false
-  edns_client_subnet:
-    custom_ip: ""
-    enabled: false
-    use_custom: false
-  max_goroutines: 300
-  handle_ddr: true
-  ipset: []
-  ipset_file: ""
-  bootstrap_prefer_ipv6: false
-  upstream_timeout: 10s
-  private_networks: []
-  use_private_ptr_resolvers: true
-  local_ptr_upstreams: []
-  use_dns64: false
-  dns64_prefixes: []
-  serve_http3: false
-  use_http3_upstreams: false
-  serve_plain_dns: true
-  hostsfile_enabled: true
-tls:
-  enabled: false
-  server_name: ""
-  force_https: false
-  port_https: 443
-  port_dns_over_tls: 853
-  port_dns_over_quic: 853
-  port_dnscrypt: 0
-  dnscrypt_config_file: ""
-  allow_unencrypted_doh: false
-  certificate_chain: ""
-  private_key: ""
-  certificate_path: ""
-  private_key_path: ""
-  strict_sni_check: false
-querylog:
-  dir_path: ""
-  ignored: []
-  interval: 24h
-  size_memory: 1000
-  enabled: true
-  file_enabled: true
-statistics:
-  dir_path: ""
-  ignored: []
-  interval: 168h
-  enabled: true
-filters:
-  - enabled: true
-    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
-    name: AdGuard DNS filter
-    id: 1
-  - enabled: true
-    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
-    name: AdAway Default Blocklist
-    id: 2
-dhcp:
-  enabled: false
-  interface_name: ""
-  local_domain_name: lan
-  dhcpv4:
-    gateway_ip: ""
-    subnet_mask: ""
-    range_start: ""
-    range_end: ""
-    lease_duration: 86400
-    icmp_timeout_msec: 1000
-    options: []
-  dhcpv6:
-    range_start: ""
-    lease_duration: 86400
-    ra_slaac_only: false
-    ra_allow_slaac: false
-filtering:
-  blocking_ipv4: ""
-  blocking_ipv6: ""
-  blocked_services:
-    schedule:
-      time_zone: UTC
-    ids: []
-  protection_disabled_until: null
-  safe_browsing_enabled: true
-  safe_browsing_cache_size: 1048576
-  safesearch_cache_size: 1048576
-  parental_cache_size: 1048576
-  parental_enabled: false
-  safesearch:
-    enabled: false
-    bing: true
-    duckduckgo: true
-    ecosia: true
-    google: true
-    pixabay: true
-    yandex: true
-    youtube: true
-  blocking_mode: default
-  rewrites: []
-clients:
-  runtime_sources:
-    whois: true
-    arp: true
-    rdns: true
-    dhcp: true
-    hosts: true
-  persistent: []
-log:
-  file: ""
-  max_backups: 0
-  max_size: 100
-  max_age: 3
-  compress: false
-  local_time: false
-  verbose: false
-os:
-  group: ""
-  user: ""
-  rlimit_nofile: 0
-schema_version: 29
-YAML
+    local default_cfg="/etc/travo/adguardhome.yaml"
+    if [ -f "$default_cfg" ]; then
+        cp "$default_cfg" "$ADGUARD_CONF"
+    else
+        # Fallback: download from repo (standalone install without tarball)
+        wget -qO "$ADGUARD_CONF" \
+            "https://raw.githubusercontent.com/raydak-labs/travo/main/packaging/adguard/AdGuardHome.yaml" \
+            || die "Failed to download AdGuard Home default config"
+    fi
     log "Config written"
 }
 
-# ---------- disable dnsmasq DNS (keep DHCP) ----------
-disable_dnsmasq_dns() {
-    local current_port
-    current_port="$(uci -q get dhcp.@dnsmasq[0].port 2>/dev/null || echo '53')"
-    if [ "$current_port" = "0" ]; then
-        log "dnsmasq DNS already disabled — skipping"
+# ---------- point dnsmasq upstream at AdGuard (port 5353) ----------
+# AdGuard listens on port 5353. dnsmasq stays on port 53 (serving DHCP clients)
+# but forwards all DNS queries upstream to AdGuard on 127.0.0.1#5353.
+configure_dnsmasq_upstream() {
+    local current
+    current="$(uci -q get dhcp.@dnsmasq[0].server 2>/dev/null || true)"
+    if echo "$current" | grep -q "127.0.0.1#5353"; then
+        log "dnsmasq upstream already points to AdGuard — skipping"
         return 0
     fi
-    log "Disabling dnsmasq DNS listener (setting port=0) ..."
-    uci set dhcp.@dnsmasq[0].port='0'
+    log "Configuring dnsmasq to forward DNS to AdGuard on 127.0.0.1#5353 ..."
+    uci set dhcp.@dnsmasq[0].noresolv='1'
+    uci -q delete dhcp.@dnsmasq[0].server 2>/dev/null || true
+    uci add_list dhcp.@dnsmasq[0].server='127.0.0.1#5353'
     uci commit dhcp
     /etc/init.d/dnsmasq restart
-    log "dnsmasq restarted (DHCP only)"
+    log "dnsmasq forwarding to AdGuard"
 }
 
 # ---------- procd init script ----------
@@ -330,6 +176,7 @@ enable_and_start() {
     log "Starting adguardhome service ..."
     "$INIT_SCRIPT" start
     log "AdGuard Home is running — web UI at http://<router-ip>:3000"
+    log "Default credentials: admin / password  (change immediately via Settings → AdGuard Password)"
 }
 
 # ---------- configure router DNS ----------
@@ -362,7 +209,7 @@ main() {
     install_binary "$arch"
     write_config
     install_init_script
-    disable_dnsmasq_dns
+    configure_dnsmasq_upstream
     configure_network_dns
     enable_and_start
 

--- a/scripts/package-tarball.sh
+++ b/scripts/package-tarball.sh
@@ -29,7 +29,8 @@ mkdir -p \
     "${STAGE_DIR}/www/travo" \
     "${STAGE_DIR}/etc/init.d" \
     "${STAGE_DIR}/etc/config" \
-    "${STAGE_DIR}/etc/uci-defaults"
+    "${STAGE_DIR}/etc/uci-defaults" \
+    "${STAGE_DIR}/etc/travo"
 
 cp "${BUILD_DIR}/travo"                                           "${STAGE_DIR}/usr/bin/travo"
 chmod +x "${STAGE_DIR}/usr/bin/travo"
@@ -38,6 +39,7 @@ cp packaging/openwrt/files/etc/init.d/travo                      "${STAGE_DIR}/e
 chmod +x "${STAGE_DIR}/etc/init.d/travo"
 cp packaging/openwrt/files/etc/config/travo                      "${STAGE_DIR}/etc/config/travo"
 cp packaging/openwrt/files/etc/uci-defaults/99-travel-gui-ports  "${STAGE_DIR}/etc/uci-defaults/99-travel-gui-ports"
+cp packaging/adguard/AdGuardHome.yaml                             "${STAGE_DIR}/etc/travo/adguardhome.yaml"
 
 OUTPUT="${BUILD_DIR}/${PKG_NAME}_${VERSION}_${ARCH}.tar.gz"
 tar -czf "${OUTPUT}" -C "${STAGE_DIR}" .

--- a/shared/src/__tests__/routes.test.ts
+++ b/shared/src/__tests__/routes.test.ts
@@ -207,6 +207,7 @@ describe('API_ROUTES', () => {
       '/api/v1/captive/auto-accept',
       '/api/v1/adguard/dns',
       '/api/v1/adguard/config',
+      '/api/v1/adguard/password',
       '/api/v1/network/uptime-log',
       '/api/v1/system/buttons',
       '/api/v1/system/button-actions',

--- a/shared/src/api/routes.ts
+++ b/shared/src/api/routes.ts
@@ -125,5 +125,6 @@ export const API_ROUTES = {
   adguard: {
     dns: '/api/v1/adguard/dns',
     config: '/api/v1/adguard/config',
+    password: '/api/v1/adguard/password',
   },
 } as const;


### PR DESCRIPTION
- Move adguardhome.yaml to packaging/adguard/AdGuardHome.yaml
- Bundle it in the install tarball at /etc/travo/adguardhome.yaml
- install-adguard.sh copies from that path; fallback downloads from GitHub
- Switch from disabling dnsmasq to forwarding its upstream to AdGuard on 127.0.0.1#5353 to match the config's dns.port: 5353