### PR TITLE
feat: add speedtest CLI service

### DIFF
--- a/backend/internal/services/speedtest_service.go
+++ b/backend/internal/services/speedtest_service.go
@@ -1,0 +1,209 @@
+package services
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/openwrt-travel-gui/backend/internal/models"
+)
+
+// SpeedtestService manages speedtest CLI installation and execution.
+type SpeedtestService struct{}
+
+// NewSpeedtestService creates a new SpeedtestService.
+func NewSpeedtestService() *SpeedtestService {
+	return &SpeedtestService{}
+}
+
+// GetSpeedtestServiceStatus returns the current status of the speedtest CLI service.
+func (s *SpeedtestService) GetSpeedtestServiceStatus() (models.SpeedtestService, error) {
+	arch, err := detectArchitecture()
+	if err != nil {
+		return models.SpeedtestService{}, fmt.Errorf("detecting architecture: %w", err)
+	}
+
+	supported := isArchitectureSupported(arch)
+	installed, version := s.checkInstallation()
+
+	return models.SpeedtestService{
+		Installed:      installed,
+		Supported:      supported,
+		Architecture:   arch,
+		Version:        version,
+		PackageName:    "speedtest",
+		StorageSizeMB:  2,
+	}, nil
+}
+
+// InstallSpeedtestCLI installs the speedtest CLI package using opkg.
+func (s *SpeedtestService) InstallSpeedtestCLI() error {
+	arch, err := detectArchitecture()
+	if err != nil {
+		return fmt.Errorf("detecting architecture: %w", err)
+	}
+
+	if !isArchitectureSupported(arch) {
+		return fmt.Errorf("architecture %s is not supported by speedtest CLI", arch)
+	}
+
+	if installed, _ := s.checkInstallation(); installed {
+		return fmt.Errorf("speedtest CLI is already installed")
+	}
+
+	out, err := exec.Command("opkg", "update").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("updating package lists: %w: %s", err, string(out))
+	}
+
+	out, err = exec.Command("opkg", "install", "speedtest").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("installing speedtest: %w: %s", err, string(out))
+	}
+
+	return nil
+}
+
+// UninstallSpeedtestCLI removes the speedtest CLI package.
+func (s *SpeedtestService) UninstallSpeedtestCLI() error {
+	if installed, _ := s.checkInstallation(); !installed {
+		return fmt.Errorf("speedtest CLI is not installed")
+	}
+
+	out, err := exec.Command("opkg", "remove", "speedtest").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("removing speedtest: %w: %s", err, string(out))
+	}
+
+	return nil
+}
+
+// RunSpeedtestCLI executes the speedtest CLI and returns parsed results.
+func (s *SpeedtestService) RunSpeedtestCLI() (models.SpeedTestResult, error) {
+	if installed, _ := s.checkInstallation(); !installed {
+		return models.SpeedTestResult{}, fmt.Errorf("speedtest CLI is not installed")
+	}
+
+	cmd := exec.Command("speedtest", "--format=json")
+	out, err := cmd.Output()
+	if err != nil {
+		return models.SpeedTestResult{}, fmt.Errorf("running speedtest: %w", err)
+	}
+
+	return parseSpeedtestOutput(string(out))
+}
+
+// checkInstallation checks if speedtest CLI is installed and returns its version.
+func (s *SpeedtestService) checkInstallation() (bool, string) {
+	path, err := exec.LookPath("speedtest")
+	if err != nil {
+		return false, ""
+	}
+
+	cmd := exec.Command(path, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return true, "unknown"
+	}
+
+	version := strings.TrimSpace(string(out))
+	re := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	if match := re.FindString(version); match != "" {
+		return true, match
+	}
+
+	return true, "unknown"
+}
+
+// detectArchitecture returns the system architecture using uname.
+func detectArchitecture() (string, error) {
+	cmd := exec.Command("uname", "-m")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("executing uname: %w", err)
+	}
+	arch := strings.TrimSpace(string(out))
+
+	// Normalize architecture names
+	archMap := map[string]string{
+		"aarch64":     "aarch64",
+		"armv7l":      "arm",
+		"armv6l":      "arm",
+		"x86_64":      "x86_64",
+		"i686":        "i386",
+		"i386":        "i386",
+		"mips":        "mips",
+		"mipsel":      "mipsel",
+		"mips64":      "mips64",
+		"mips64el":    "mips64el",
+	}
+
+	if normalized, ok := archMap[arch]; ok {
+		return normalized, nil
+	}
+
+	return arch, nil
+}
+
+// isArchitectureSupported checks if the architecture supports speedtest CLI.
+func isArchitectureSupported(arch string) bool {
+	supportedArchs := map[string]bool{
+		"aarch64":  true,
+		"arm":      true,
+		"x86_64":   true,
+		"i386":     true,
+		"mips":     true,
+		"mipsel":   true,
+		"mips64":   true,
+		"mips64el": true,
+	}
+
+	return supportedArchs[arch]
+}
+
+// parseSpeedtestOutput parses JSON output from speedtest CLI.
+func parseSpeedtestOutput(output string) (models.SpeedTestResult, error) {
+	result := models.SpeedTestResult{}
+
+	reDownload := regexp.MustCompile(`"download":\s*\{[^}]*"bandwidth":\s*([\d.]+)`)
+	reUpload := regexp.MustCompile(`"upload":\s*\{[^}]*"bandwidth":\s*([\d.]+)`)
+	rePing := regexp.MustCompile(`"ping":\s*\{[^}]*"latency":\s*([\d.]+)`)
+	reServer := regexp.MustCompile(`"server":\s*\{[^}]*"name":\s*"([^"]+)"`)
+
+	downloadMBps := 0.0
+	uploadMBps := 0.0
+	pingMs := 0.0
+	server := "unknown"
+
+	if match := reDownload.FindStringSubmatch(output); len(match) > 1 {
+		bandwidth := parseFloat(match[1])
+		downloadMBps = bandwidth / 125000 // Convert bits/s to Mbps
+	}
+
+	if match := reUpload.FindStringSubmatch(output); len(match) > 1 {
+		bandwidth := parseFloat(match[1])
+		uploadMBps = bandwidth / 125000
+	}
+
+	if match := rePing.FindStringSubmatch(output); len(match) > 1 {
+		pingMs = parseFloat(match[1])
+	}
+
+	if match := reServer.FindStringSubmatch(output); len(match) > 1 {
+		server = match[1]
+	}
+
+	result.DownloadMbps = downloadMBps
+	result.UploadMbps = uploadMBps
+	result.PingMs = pingMs
+	result.Server = server
+
+	return result, nil
+}
+
+func parseFloat(s string) float64 {
+	var f float64
+	fmt.Sscanf(s, "%f", &f)
+	return f
+}

--- a/backend/internal/services/speedtest_service_test.go
+++ b/backend/internal/services/speedtest_service_test.go
@@ -1,0 +1,162 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestNewSpeedtestService(t *testing.T) {
+	svc := NewSpeedtestService()
+	if svc == nil {
+		t.Fatal("NewSpeedtestService returned nil")
+	}
+}
+
+func TestGetSpeedtestServiceStatus(t *testing.T) {
+	svc := NewSpeedtestService()
+	status, err := svc.GetSpeedtestServiceStatus()
+	if err != nil {
+		t.Fatalf("GetSpeedtestServiceStatus failed: %v", err)
+	}
+
+	if status.Architecture == "" {
+		t.Error("Architecture should not be empty")
+	}
+
+	if status.PackageName != "speedtest" {
+		t.Errorf("PackageName should be 'speedtest', got %s", status.PackageName)
+	}
+
+	if status.StorageSizeMB < 1 || status.StorageSizeMB > 10 {
+		t.Errorf("StorageSizeMB should be between 1 and 10, got %d", status.StorageSizeMB)
+	}
+}
+
+func TestCheckInstallation(t *testing.T) {
+	svc := NewSpeedtestService()
+
+	installed, version := svc.checkInstallation()
+
+	if installed && version == "" {
+		t.Error("Version should not be empty when installed is true")
+	}
+
+	if !installed && version != "" {
+		t.Error("Version should be empty when installed is false")
+	}
+}
+
+func TestDetectArchitecture(t *testing.T) {
+	arch, err := detectArchitecture()
+	if err != nil {
+		t.Fatalf("detectArchitecture failed: %v", err)
+	}
+
+	if arch == "" {
+		t.Error("Architecture should not be empty")
+	}
+
+	validArches := map[string]bool{
+		"aarch64": true, "arm": true, "x86_64": true,
+		"i386": true, "mips": true, "mipsel": true,
+		"mips64": true, "mips64el": true,
+	}
+
+	if !validArches[arch] {
+		t.Logf("Warning: Unknown architecture detected: %s", arch)
+	}
+}
+
+func TestIsArchitectureSupported(t *testing.T) {
+	tests := []struct {
+		arch      string
+		supported bool
+	}{
+		{"aarch64", true},
+		{"arm", true},
+		{"x86_64", true},
+		{"i386", true},
+		{"mips", true},
+		{"mipsel", true},
+		{"mips64", true},
+		{"mips64el": true},
+		{"riscv64", false},
+		{"ppc64le", false},
+	}
+
+	for _, tt := range tests {
+		result := isArchitectureSupported(tt.arch)
+		if result != tt.supported {
+			t.Errorf("isArchitectureSupported(%s) = %v, want %v", tt.arch, result, tt.supported)
+		}
+	}
+}
+
+func TestParseSpeedtestOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid JSON",
+			input:   `{"type":"result","download":{"bandwidth":50000000},"upload":{"bandwidth":10000000},"ping":{"latency":15.5},"server":{"name":"Test Server"}}`,
+			wantErr: false,
+		},
+		{
+			name:    "empty output",
+			input:   "",
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			input:   "not json",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseSpeedtestOutput(tt.input)
+			if !tt.wantErr {
+				if err != nil {
+					t.Errorf("parseSpeedtestOutput() unexpected error: %v", err)
+				}
+				return
+			}
+
+			if tt.name == "valid JSON" {
+				if result.DownloadMbps < 300 || result.DownloadMbps > 500 {
+					t.Errorf("DownloadMbps out of expected range: %f", result.DownloadMbps)
+				}
+				if result.UploadMbps < 50 || result.UploadMbps > 100 {
+					t.Errorf("UploadMbps out of expected range: %f", result.UploadMbps)
+				}
+				if result.PingMs < 10 || result.PingMs > 20 {
+					t.Errorf("PingMs out of expected range: %f", result.PingMs)
+				}
+				if result.Server != "Test Server" {
+					t.Errorf("Server = %s, want Test Server", result.Server)
+				}
+			}
+		})
+	}
+}
+
+func TestparseFloat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"123.456", 123.456},
+		{"0", 0},
+		{"-5.5", -5.5},
+		{"invalid", 0},
+	}
+
+	for _, tt := range tests {
+		got := parseFloat(tt.input)
+		if got != tt.want {
+			t.Errorf("parseFloat(%s) = %f, want %f", tt.input, got, tt.want)
+		}
+	}
+}

--- a/frontend/src/pages/system/system-speedtest-service-card.tsx
+++ b/frontend/src/pages/system/system-speedtest-service-card.tsx
@@ -1,0 +1,259 @@
+import { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Activity,
+  Download,
+  Upload,
+  Clock,
+  Server,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  Package,
+  Trash2,
+  Loader2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  useSpeedtestService,
+  useInstallSpeedtestCLI,
+  useUninstallSpeedtestCLI,
+  useRunSpeedtestCLI,
+} from '@/hooks/use-system';
+import type { SpeedTestResult } from '@shared/index';
+
+export function SystemSpeedtestServiceCard() {
+  const [testResult, setTestResult] = useState<SpeedTestResult | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  
+  const { data: service, isLoading: isLoadingService } = useSpeedtestService();
+  const installMutation = useInstallSpeedtestCLI();
+  const uninstallMutation = useUninstallSpeedtestCLI();
+  const runMutation = useRunSpeedtestCLI();
+
+  const handleInstall = () => {
+    installMutation.mutate();
+  };
+
+  const handleUninstall = () => {
+    uninstallMutation.mutate();
+  };
+
+  const handleRun = () => {
+    setIsRunning(true);
+    setTestResult(null);
+    
+    runMutation.mutate(undefined, {
+      onSuccess: (result) => {
+        setTestResult(result);
+        setIsRunning(false);
+      },
+      onError: () => {
+        setIsRunning(false);
+      },
+    });
+  };
+
+  if (isLoadingService) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Speedtest Service</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!service) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Speedtest Service</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center text-sm text-gray-500 py-4">
+            Unable to load speedtest service status
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const getStatusBadge = () => {
+    if (!service.supported) {
+      return (
+        <Badge variant="destructive" className="gap-2">
+          <XCircle className="h-4 w-4" />
+          Not Supported
+        </Badge>
+      );
+    }
+    if (service.installed) {
+      return (
+        <Badge variant="default" className="gap-2">
+          <CheckCircle2 className="h-4 w-4" />
+          Installed
+        </Badge>
+      );
+    }
+    return (
+      <Badge variant="secondary" className="gap-2">
+        <AlertTriangle className="h-4 w-4" />
+        Not Installed
+      </Badge>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2">
+            <Activity className="h-5 w-5" />
+            Speedtest Service
+          </CardTitle>
+          {getStatusBadge()}
+        </div>
+        <CardDescription>
+          {service.supported
+            ? `Run internet speed tests using Speedtest.net CLI. Architecture: ${service.architecture}`
+            : `${service.architecture} architecture is not supported by Speedtest.net CLI`}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <div className="text-gray-500">Architecture</div>
+            <div className="font-medium">{service.architecture}</div>
+          </div>
+          <div>
+            <div className="text-gray-500">Package</div>
+            <div className="font-medium">{service.package_name}</div>
+          </div>
+          {service.version && (
+            <div>
+              <div className="text-gray-500">Version</div>
+              <div className="font-medium">{service.version}</div>
+            </div>
+          )}
+          <div>
+            <div className="text-gray-500">Storage Required</div>
+            <div className="font-medium">~{service.storage_size_mb} MB</div>
+          </div>
+        </div>
+
+        {!service.installed && service.supported && (
+          <div className="flex gap-2">
+            <Button
+              onClick={handleInstall}
+              disabled={installMutation.isPending}
+              className="flex-1"
+            >
+              <Package className="h-4 w-4 mr-2" />
+              {installMutation.isPending ? 'Installing...' : 'Install Speedtest CLI'}
+            </Button>
+          </div>
+        )}
+
+        {service.installed && (
+          <div className="space-y-4">
+            <Button
+              onClick={handleRun}
+              disabled={isRunning}
+              className="w-full"
+            >
+              {isRunning ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Running Speed Test...
+                </>
+              ) : (
+                <>
+                  <Activity className="h-4 w-4 mr-2" />
+                  Run Speed Test
+                </>
+              )}
+            </Button>
+
+            <Button
+              variant="destructive"
+              onClick={handleUninstall}
+              disabled={uninstallMutation.isPending}
+              className="w-full"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              {uninstallMutation.isPending ? 'Uninstalling...' : 'Uninstall'}
+            </Button>
+
+            {testResult && (
+              <div className="rounded-lg border bg-card p-4 space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <CheckCircle2 className="h-5 w-5 text-green-500" />
+                  Speed Test Complete
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <Download className="h-4 w-4" />
+                      Download
+                    </div>
+                    <div className="text-2xl font-bold">
+                      {testResult.download_mbps.toFixed(2)}
+                    </div>
+                    <div className="text-xs text-gray-500">Mbps</div>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <Upload className="h-4 w-4" />
+                      Upload
+                    </div>
+                    <div className="text-2xl font-bold">
+                      {testResult.upload_mbps.toFixed(2)}
+                    </div>
+                    <div className="text-xs text-gray-500">Mbps</div>
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <Clock className="h-4 w-4" />
+                      Ping
+                    </div>
+                    <div className="text-2xl font-bold">
+                      {testResult.ping_ms.toFixed(1)}
+                    </div>
+                    <div className="text-xs text-gray-500">ms</div>
+                  </div>
+                </div>
+                {testResult.server && (
+                  <div className="flex items-center gap-2 text-sm text-gray-500 pt-2">
+                    <Server className="h-4 w-4" />
+                    Server: {testResult.server}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {!service.supported && (
+          <div className="rounded-lg bg-destructive/10 p-4 text-sm text-destructive">
+            Your device architecture ({service.architecture}) is not supported by the Speedtest.net CLI.
+            Only these architectures are supported: aarch64, arm, x86_64, i386, mips, mipsel.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Add SpeedtestService model and service for tracking install status and architecture support. Install/uninstall CLI via opkg with arch validation (aarch64, arm, x86_64, i386, mips, mipsel). Parse JSON output from speedtest --format=json. Add API handlers, routes, TypeScript types, React hooks, and UI component. Display download, upload, ping results with nice UI and unsupported architecture warnings. Add tests for service methods.