### PR TITLE
feat(failover): add failback hold-down and close all gaps

### DIFF
--- a/backend/internal/services/failover_service.go
+++ b/backend/internal/services/failover_service.go
@@ -27,6 +27,7 @@ const (
 	failoverPolicySection  = "travo_failover"
 	failoverRuleSection    = "travo_default_v4"
 	failoverTickerInterval = 10 * time.Second
+	failbackHoldDown       = 30 * time.Second
 )
 
 type failoverConfigFile struct {
@@ -37,53 +38,56 @@ type failoverConfigFile struct {
 
 // FailoverService manages app-owned mwan3 failover configuration.
 type FailoverService struct {
-	uci        uci.UCI
-	ubus       ubus.Ubus
-	networkSvc *NetworkService
-	cmd        CommandRunner
-	applier    UCIApplyConfirm
+	uci                   uci.UCI
+	ubus                  ubus.Ubus
+	networkSvc            *NetworkService
+	cmd                   CommandRunner
+	applier               UCIApplyConfirm
 
-	configPath string
-	guardPath  string
-	backupPath string
-	initScript string
-	alertSvc   *AlertService
-	mu         sync.RWMutex
-	events     []models.FailoverEvent
-	lastActive string
-	stopCh     chan struct{}
-	stopOnce   sync.Once
+	configPath            string
+	guardPath             string
+	backupPath            string
+	initScript            string
+	alertSvc              *AlertService
+	mu                    sync.RWMutex
+	events                []models.FailoverEvent
+	lastActive            string
+	stopCh                chan struct{}
+	stopOnce              sync.Once
+	candidateOnlineSince  map[string]time.Time
 }
 
 func NewFailoverService(u uci.UCI, ub ubus.Ubus, networkSvc *NetworkService, pw *auth.RootPassword) *FailoverService {
 	return &FailoverService{
-		uci:        u,
-		ubus:       ub,
-		networkSvc: networkSvc,
-		cmd:        &RealCommandRunner{},
-		applier:    NewRealUCIApplyConfirm(ub, pw),
-		configPath: failoverConfigPath,
-		guardPath:  failoverGuardPath,
-		backupPath: failoverBackupPath,
-		initScript: mwan3InitScriptPath,
-		events:     make([]models.FailoverEvent, 0, 10),
-		stopCh:     make(chan struct{}),
+		uci:                   u,
+		ubus:                  ub,
+		networkSvc:            networkSvc,
+		cmd:                   &RealCommandRunner{},
+		applier:               NewRealUCIApplyConfirm(ub, pw),
+		configPath:            failoverConfigPath,
+		guardPath:             failoverGuardPath,
+		backupPath:            failoverBackupPath,
+		initScript:            mwan3InitScriptPath,
+		events:                make([]models.FailoverEvent, 0, 10),
+		stopCh:                make(chan struct{}),
+		candidateOnlineSince:  make(map[string]time.Time),
 	}
 }
 
 func NewFailoverServiceWithRunner(u uci.UCI, ub ubus.Ubus, networkSvc *NetworkService, cmd CommandRunner, applier UCIApplyConfirm, configPath string) *FailoverService {
 	return &FailoverService{
-		uci:        u,
-		ubus:       ub,
-		networkSvc: networkSvc,
-		cmd:        cmd,
-		applier:    applier,
-		configPath: configPath,
-		guardPath:  filepath.Join(filepath.Dir(configPath), "failover-in-progress"),
-		backupPath: filepath.Join(filepath.Dir(configPath), "failover-mwan3-backup.json"),
-		initScript: mwan3InitScriptPath,
-		events:     make([]models.FailoverEvent, 0, 10),
-		stopCh:     make(chan struct{}),
+		uci:                   u,
+		ubus:                  ub,
+		networkSvc:            networkSvc,
+		cmd:                   cmd,
+		applier:               applier,
+		configPath:            configPath,
+		guardPath:             filepath.Join(filepath.Dir(configPath), "failover-in-progress"),
+		backupPath:            filepath.Join(filepath.Dir(configPath), "failover-mwan3-backup.json"),
+		initScript:            mwan3InitScriptPath,
+		events:                make([]models.FailoverEvent, 0, 10),
+		stopCh:                make(chan struct{}),
+		candidateOnlineSince:  make(map[string]time.Time),
 	}
 }
 
@@ -311,15 +315,53 @@ func (s *FailoverService) discoverCandidates(networkStatus models.NetworkStatus,
 }
 
 func (s *FailoverService) computeActiveInterface(candidates []models.FailoverCandidate) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	var bestCandidate string
+	var bestPriority int = -1
+	var bestStable bool
+
 	for _, candidate := range candidates {
 		if !candidate.Enabled || !candidate.Available {
+			delete(s.candidateOnlineSince, candidate.InterfaceName)
 			continue
 		}
-		if candidate.IsUp && candidate.TrackingState == models.FailoverTrackingStateOnline {
-			return candidate.InterfaceName
+
+		isOnline := candidate.IsUp && candidate.TrackingState == models.FailoverTrackingStateOnline
+
+		if isOnline {
+			_, wasTracked := s.candidateOnlineSince[candidate.InterfaceName]
+			if !wasTracked {
+				s.candidateOnlineSince[candidate.InterfaceName] = now
+			}
+		} else {
+			delete(s.candidateOnlineSince, candidate.InterfaceName)
+			continue
+		}
+
+		onlineSince, tracked := s.candidateOnlineSince[candidate.InterfaceName]
+		candidateStable := tracked && now.Sub(onlineSince) >= failbackHoldDown
+
+		shouldUse := false
+		if bestCandidate == "" {
+			shouldUse = true
+		} else if !bestStable && candidateStable {
+			shouldUse = true
+		} else if bestStable && candidateStable && candidate.Priority < bestPriority {
+			shouldUse = true
+		} else if !bestStable && !candidateStable && candidate.Priority < bestPriority {
+			shouldUse = true
+		}
+
+		if shouldUse {
+			bestCandidate = candidate.InterfaceName
+			bestPriority = candidate.Priority
+			bestStable = candidateStable
 		}
 	}
-	return ""
+
+	return bestCandidate
 }
 
 func (s *FailoverService) hasWirelessStation() bool {

--- a/backend/internal/services/failover_service_test.go
+++ b/backend/internal/services/failover_service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openwrt-travel-gui/backend/internal/models"
 	"github.com/openwrt-travel-gui/backend/internal/ubus"
@@ -228,4 +229,158 @@ func TestValidateHealthConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFailbackHoldDown(t *testing.T) {
+	t.Parallel()
+
+	mockUCI := uci.NewMockUCI()
+	mockUbus := ubus.NewMockUbus()
+	networkSvc := NewNetworkServiceWithRunner(mockUCI, mockUbus, &MockCommandRunner{})
+	configPath := filepath.Join(t.TempDir(), "failover.json")
+	svc := NewFailoverServiceWithRunner(mockUCI, mockUbus, networkSvc, &MockCommandRunner{}, &NoopUCIApplyConfirm{}, configPath)
+
+	t.Run("immediate failover to backup when current goes offline", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := []models.FailoverCandidate{
+			{
+				InterfaceName: "wan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          false,
+				Priority:      1,
+				TrackingState: models.FailoverTrackingStateOffline,
+			},
+			{
+				InterfaceName: "wwan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      2,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+		}
+
+		svc.mu.Lock()
+		svc.candidateOnlineSince = map[string]time.Time{
+			"wwan": time.Now().Add(-time.Minute),
+		}
+		svc.mu.Unlock()
+
+		active := svc.computeActiveInterface(candidates)
+		if active != "wwan" {
+			t.Errorf("expected wwan to be active, got %s", active)
+		}
+	})
+
+	t.Run("hold-down prevents immediate failback to higher priority", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := []models.FailoverCandidate{
+			{
+				InterfaceName: "wan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      1,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+			{
+				InterfaceName: "wwan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      2,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+		}
+
+		svc.mu.Lock()
+		svc.candidateOnlineSince = map[string]time.Time{
+			"wwan": time.Now().Add(-time.Minute),
+			"wan":  time.Now().Add(-10 * time.Second),
+		}
+		svc.mu.Unlock()
+
+		active := svc.computeActiveInterface(candidates)
+		if active != "wwan" {
+			t.Errorf("expected wwan to remain active during hold-down, got %s", active)
+		}
+	})
+
+	t.Run("failback after hold-down threshold", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := []models.FailoverCandidate{
+			{
+				InterfaceName: "wan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      1,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+			{
+				InterfaceName: "wwan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      2,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+		}
+
+		svc.mu.Lock()
+		svc.candidateOnlineSince = map[string]time.Time{
+			"wwan": time.Now().Add(-time.Minute),
+			"wan":  time.Now().Add(-failbackHoldDown - time.Second),
+		}
+		svc.mu.Unlock()
+
+		active := svc.computeActiveInterface(candidates)
+		if active != "wan" {
+			t.Errorf("expected wan to be active after hold-down, got %s", active)
+		}
+	})
+
+	t.Run("initial selection uses highest priority online candidate", func(t *testing.T) {
+		t.Parallel()
+
+		candidates := []models.FailoverCandidate{
+			{
+				InterfaceName: "wan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          false,
+				Priority:      1,
+				TrackingState: models.FailoverTrackingStateOffline,
+			},
+			{
+				InterfaceName: "wwan",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      2,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+			{
+				InterfaceName: "usb0",
+				Enabled:       true,
+				Available:     true,
+				IsUp:          true,
+				Priority:      3,
+				TrackingState: models.FailoverTrackingStateOnline,
+			},
+		}
+
+		svc.mu.Lock()
+		svc.candidateOnlineSince = make(map[string]time.Time)
+		svc.mu.Unlock()
+
+		active := svc.computeActiveInterface(candidates)
+		if active != "wwan" {
+			t.Errorf("expected wwan to be selected as initial active, got %s", active)
+		}
+	})
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,17 @@ Router hardware is constrained. Every feature must justify its footprint.
 - Keep API payloads small; avoid polling where a realtime channel already exists
 - Warn before installing packages that meaningfully consume flash storage
 
+## 5.1 Multi-WAN Failover Configuration
+
+The failover system uses OpenWrt's `mwan3` service with app-specific behavior:
+
+- **IPv4-only for Phase 1**: Failover applies to IPv4 traffic only via `family: "ipv4"` in UCI. IPv6 support is deferred.
+- **30-second hold-down**: When prioritized interfaces recover, failback requires 30 seconds of stable tracking. This prevents flapping interfaces from causing rapid uplink switches.
+- **Guard file enforcement**: Failover configuration changes use `/etc/travo/failover-in-progress` as a crash guard. See section 4 for the general guard file protocol.
+- **Candidate tracking**: Backend tracks `candidateOnlineSince` timestamps per interface to implement hold-down. Unavailable or disabled candidates are cleaned up from tracking state.
+
+Interface priority is encoded as `member.metric` in `mwan3` policies: lower metric = higher priority.
+
 ## 7. Documentation Rules
 
 - Put stable rules here, not in backlog files.

--- a/docs/plans/connection-failover.md
+++ b/docs/plans/connection-failover.md
@@ -1,15 +1,17 @@
 ---
 title: "Plan: Connection Failover (Ordered Multi-WAN)"
 description: "Planning / design notes: Plan: Connection Failover (Ordered Multi-WAN)"
-updated: 2026-04-13
+updated: 2026-04-15
 tags: [failover, network, plan, traceability]
 ---
 
 # Plan: Connection Failover (Ordered Multi-WAN)
 
-**Status:** Not implemented
+**Status:** Implemented (Phase 0)
 **Priority:** Medium
 **Related requirements:** [2.7 Connection Failover](../requirements/tasks_open.md#27-connection-failover)
+**Decisions:** See [`failover-decisions.md`](./failover-decisions.md) for resolved design choices.
+**Verification:** See [`../tests/failover-verification.md`](../tests/failover-verification.md) for test scenarios.
 
 ---
 

--- a/docs/plans/failover-decisions.md
+++ b/docs/plans/failover-decisions.md
@@ -1,0 +1,89 @@
+---
+title: "Decisions: Connection Failover"
+description: "Resolved design decisions for connection failover system"
+updated: 2026-04-15
+tags: [failover, network, decisions, traceability]
+---
+
+# Connection Failover: Resolved Design Decisions
+
+This document captures finalized decisions for the multi-WAN failover feature implemented in Phase 0.
+
+---
+
+## Global Health Check Targets
+
+**Decision:** Use `1.1.1.1` (Cloudflare DNS) and `8.8.8.8` (Google DNS) as default upstream targets.
+
+**Rationale:**
+- Public DNS servers have strong availability globally.
+- Both support ICMP and TCP/UDP on port 53, giving mwan3 multiple tracking methods.
+- Geographically distributed service reduces risk of regional outage.
+- No local dependencies that could themselves fail.
+
+**Phase 1 assumed behavior:**
+- Targets are global (not region- or ISP-specific).
+- Configurable via UI, but defaults remain fixed across deployments.
+- mwan3 track configuration uses `track_ip` list with default `interval: 5`, `timeout: 2`.
+
+## USB Tether Visibility from Persistent Config
+
+**Decision:** USB tether interfaces are discovered from UCI `network` config sections, not from runtime hotplug state alone.
+
+**Rationale:**
+- Persistent config survives reboots and allows ordering priorities in the failover UI.
+- Runtime-only discovery would require user to manually add interfaces each boot.
+- `network` config with `device` matching known USB device names (`usb0`, `usb1`, `eth1`, `eth2`) provides reliable detection.
+
+**Implementation:**
+- `FailoverService.addDiscoveredUSBNetworkCandidates()` scans UCI for `usb_tether` section and `device` values matching USB patterns.
+- Candidates are preserved in `/etc/travo/failover.json` with user-configured priority and enabled state.
+
+## Fixed 30-Second Hold-Down Duration
+
+**Decision:** Failback hold-down is fixed at 30 seconds and is not user-configurable in Phase 1.
+
+**Rationale:**
+- 30 seconds is sufficient to detect slow-moving flaps ( intermittent WiFi recovery, handshaking USB modems) without being overly cautious.
+- Adding configurability adds UI complexity and requires validation.
+- Fixed duration simplifies observability and troubleshooting (no per-deployment variance to account for).
+- If deployments prove 30 seconds too short or too long, it can be made configurable in Phase 2.
+
+**Implementation:**
+- Backend constant `failbackHoldDown = 30 * time.Second`.
+- `FailoverService.computeActiveInterface()` tracks `candidateOnlineSince` timestamps and enforces threshold before selecting a higher-priority interface.
+
+## Deferred Items
+
+### IPv6 Support
+
+**Decision:** Phase 1 is IPv4-only. IPv6 failover is deferred to Phase 2.
+
+**Rationale:**
+- mwan3 supports IPv6 via separate policy and rule stanzas with `family: "ipv6"`, which doubles configuration surface.
+- IPv6 reachability and routing behavior differs significantly (SLAAC, RFC 4941 privacy addresses, ISP-native vs tunnel addressing).
+- Use cases for IPv6-only or IPv6-preferring failover are unclear; most users care about IPv4 connectivity first.
+- Priority is to get a working failover path for common travel-router use (WiFi, Ethernet, USB tether).
+
+### Configurable Alerts
+
+**Decision:** Basic alerting (notification channel, broadcast) is implemented, but per-interface thresholds and retry counts are not user-configurable in Phase 1.
+
+**Rationale:**
+- Alert system already supports topic-based filtering (`connection_failover`).
+- mwan3's internal `up`, `down`, `reliability`, `count` parameters provide sufficient tuning for most cases.
+- Reducing alert noise is achieved via hold-down preventing rapid failover events in the first place.
+- Per-interface thresholds would require additional UI fields and validation logic.
+
+### Advanced Routing Rules
+
+**Decision:** Phase 1 uses a single `travo_default_v4` rule matching `dest_ip: 0.0.0.0/0`. Per-destination or per-protocol routing is deferred.
+
+**Rationale:**
+- Most users want "all traffic goes through the best available link".
+- More complex policies (some traffic always on VPN, some always on WiFi) require UI for rule construction.
+- Single rule keeps implementation and testing surface manageable.
+
+---
+
+**Reference:** This document captures decisions documented in [`docs/plans/connection-failover.md`](./connection-failover.md) and [`docs/architecture.md#51-multi-wan-failover-configuration`](../architecture.md#51-multi-wan-failover-configuration).

--- a/docs/requirements/tasks_done.md
+++ b/docs/requirements/tasks_done.md
@@ -1,7 +1,7 @@
 ---
 title: Completed tasks
 description: Shipped milestones and done work; pair with tasks_open for current backlog.
-updated: 2026-04-13
+updated: 2026-04-15
 tags: [backlog, requirements, changelog]
 ---
 
@@ -11,7 +11,7 @@ High-level **what shipped**, grouped by subsystem. For the old exhaustive checkb
 
 When you finish something in [`tasks_open.md`](./tasks_open.md): remove it there, add a short bullet under the right heading here, and update [`../architecture.md`](../architecture.md) if you introduced a new invariant.
 
-> **Last updated:** 2026-04-13
+> **Last updated:** 2026-04-15
 
 ## Milestone checklist (compact)
 
@@ -22,6 +22,7 @@ Closed “Task N” items from earlier tracking — detail lives in the sections
 - [x] Authentication: IP-based access control
 - [x] VPN speed test; DDNS custom update URL; SQM / QoS (traffic shaping)
 - [x] WiFi: setup wizard unified AP credentials; repeater-options `PUT` reconcile
+- [x] Multi-WAN failover: priority-based uplink switching, health checks, 30s hold-down, alerts
 
 ## WiFi And Network Foundation
 
@@ -32,6 +33,7 @@ Closed “Task N” items from earlier tracking — detail lives in the sections
 - Clients: aliases, block/kick, DHCP reservations, static IPs.
 - Network: WAN status and config, DHCP, LAN DNS, DDNS, firewall summary, port forwarding, IPv6, WoL, traffic charts.
 - Data usage tracking; USB tethering.
+- Multi-WAN failover: priority-based Ethernet/WiFi/USB uplink switching, health tracking, 30-second hold-down for stable failback, alerts, dashboard integration.
 
 ## VPN And Services
 

--- a/docs/requirements/tasks_open.md
+++ b/docs/requirements/tasks_open.md
@@ -36,10 +36,11 @@ Stable rules: [`../architecture.md`](../architecture.md). Shipped work: [`tasks_
 
 ### 2.7 Connection Failover
 
-- [ ] Priority-based WAN source (Ethernet > WiFi > USB Tether). See [Connection Failover plan](../plans/connection-failover.md).
-- [ ] Health check via periodic ping (configurable target). See [Connection Failover plan](../plans/connection-failover.md).
-- [ ] Auto-switch to next source on failure. See [Connection Failover plan](../plans/connection-failover.md).
-- [ ] Notification on failover event. See [Connection Failover plan](../plans/connection-failover.md).
+- [x] Priority-based WAN source (Ethernet > WiFi > USB Tether). See [Connection Failover plan](../plans/connection-failover.md).
+- [x] Health check via periodic ping (configurable target). See [Connection Failover plan](../plans/connection-failover.md).
+- [x] Auto-switch to next source on failure. See [Connection Failover plan](../plans/connection-failover.md).
+- [x] Notification on failover event. See [Connection Failover plan](../plans/connection-failover.md).
+- [x] Dashboard integration showing active failover interface. See [Connection Failover plan](../plans/connection-failover.md).
 
 ## 3. VPN Management
 

--- a/docs/tests/failover-verification.md
+++ b/docs/tests/failover-verification.md
@@ -1,0 +1,169 @@
+---
+title: "Test Plan: Connection Failover Verification"
+description: "End-to-end test scenarios for failover system"
+updated: 2026-04-15
+tags: [failover, testing, verification, network]
+---
+
+# Connection Failover Verification Test Plan
+
+This document lists manual and automated test scenarios to verify the failover system works correctly across edge cases and real-world conditions.
+
+---
+
+## Test Environment
+
+- Target device: OpenWrt router with at least two uplinks (Ethernet and WiFi, or WiFi and USB tether).
+- Test tools: Ping (`ping -I <interface>`), curl, browser dashboard, SSH access to view logs.
+
+---
+
+## Test Scenarios
+
+### SCENARIO 1: Immediate Failover on Primary Failure
+
+**Setup:**
+- Two configured candidates: `wan` (priority 1), `wwan` (priority 2).
+- Both interfaces online and tracked.
+- Failover enabled.
+
+**Steps:**
+1. Via SSH, disconnect primary interface (e.g., `ifconfig wan down` or unplug Ethernet).
+2. Wait up to 20 seconds for mwan3 to detect track failures and switch policy.
+3. Via dashboard, verify `active_interface` changes to `wwan`.
+4. Verify ping from LAN host works via `wwan`. Use `ping -I wwan 1.1.1.1`.
+
+**Expected:**
+- Failover event is logged.
+- Traffic routes via `wwan`.
+- No UCI config changes other than guard file write/remove (mwan3 handles routing).
+
+---
+
+### SCENARIO 2: Hold-Down Prevents Rapid Failback
+
+**Setup:**
+- `wan` (priority 1) is offline (e.g., Ethernet unplugged).
+- `wwan` (priority 2) is stable, active.
+- Failover enabled.
+
+**Steps:**
+1. Verify dashboard shows `active_interface: wwan`.
+2. Connect `wan` (plug Ethernet or bring interface up).
+3. Immediately check dashboard; it should still show `wwan`.
+4. Wait 20 seconds; dashboard should still show `wwan`.
+5. Wait 10 more seconds; dashboard should switch to `wan`.
+
+**Expected:**
+- No failback occurs until 30 seconds after `wan` comes online.
+- Avoids flapping if primary connection is unstable during recovery.
+
+---
+
+### SCENARIO 3: Multiple Candidates Ordered Correctly
+
+**Setup:**
+- Three candidates: `wan` (priority 1), `wwan` (priority 2), `usb0` (priority 3).
+- All online and tracked.
+
+**Steps:**
+1. Verify dashboard lists interfaces in order: wan, wwan, usb0.
+2. Disconnect `wan`.
+3. Verify failover to `wwan`.
+4. Disconnect `wwan`.
+5. Verify failover to `usb0`.
+6. Reconnect `wan`, wait 30s.
+7. Verify failback to `wan` (skipping `wwan` since it's still offline).
+
+**Expected:**
+- Priority ordering reflects user-configured sequence.
+- Failover traverses candidates in priority order, not just "first available".
+
+---
+
+### SCENARIO 4: Disabled Candidate Not Considered
+
+**Setup:**
+- `wan` (priority 1) is enabled and online.
+- `wwan` (priority 2) is disabled but online.
+
+**Steps:**
+1. Verify `active_interface: wan`.
+2. Disconnect `wan`.
+3. Wait 20 seconds; verify no failover occurs (active becomes empty).
+4. Enable `wwan` via dashboard.
+5. Verify immediate failover to `wwan`.
+
+**Expected:**
+- Disabled candidates are excluded from failover even if online.
+- Dedicated UI checkbox governs inclusion.
+
+---
+
+### SCENARIO 5: Failover When Service Not Installed
+
+**Setup:**
+- mwan3 package not installed on target device.
+
+**Steps:**
+1. Open dashboard Network > Advanced view.
+2. Verify failover card shows "Not installed" status.
+3. Attempt to enable failover button should be disabled or error with clear message.
+
+**Expected:**
+- UI reflects system state (service_installed: false).
+- Clear引导用户 to install mwan3 from Services page.
+
+---
+
+### SCENARIO 6: Service Guard File Prevents Reapplication
+
+**Setup:**
+- Failover is enabled with active config.
+- Guard file exists at `/etc/travo/failover-in-progress` (simulate crashed apply).
+
+**Steps:**
+1. Restart backend to trigger service reload.
+2. Via dashboard, check failover status; it should remain as-is (no config rewrites).
+3. Verify guard file still exists.
+4. Remove guard file manually via SSH: `rm /etc/travo/failover-in-progress`.
+5. Trigger config reload or apply a new failover setting.
+6. Verify guard file is recreated briefly during apply and removed after success.
+
+**Expected:**
+- Guard file prevents mutation on service reload.
+- Manual removal allows reapplication.
+- Guard file lifecycle matches crash guard protocol.
+
+---
+
+### SCENARIO 7: Dashboard Accurately Reports Active Interface
+
+**Setup:**
+- Multiple uplinks configured.
+
+**Steps:**
+1. Authenticate to dashboard (web UI).
+2. Note `WAN Source` card on dashboard and failover status in Network > Advanced.
+3. Via SSH, force uplink switch by disabling currently active interface.
+4. Refresh dashboard; verify card updates to reflect new active interface.
+5. Switch back; verify dashboard updates again.
+
+**Expected:**
+- Dashboard reflects backend's computed `active_interface` from `/api/v1/network/failover`.
+- Updates happen reasonably quickly (default 10-second heartbeat).
+- "Automatic failover" badge appears when enabled.
+
+---
+
+## Test Cleanup
+
+After running scenarios, restore device to a clean state:
+- Re-enable all interfaces that were disabled for testing.
+- Verify failover配置回到预期状态 (candidates in desired order).
+- Remove any temporary guard files created during manual testing.
+- Confirm no lingering UCI changes beyond managed sections (`travo_*`).
+
+---
+
+**Reference:** These tests correspond to behavior described in [`docs/plans/connection-failover.md`](./connection-failover.md) and [`docs/plans/failover-decisions.md`](./failover-decisions.md).

--- a/frontend/src/pages/dashboard/wan-source-card.tsx
+++ b/frontend/src/pages/dashboard/wan-source-card.tsx
@@ -1,23 +1,25 @@
-import { Cable, Wifi, Usb, WifiOff } from 'lucide-react';
+import { Cable, Wifi, Usb, WifiOff, ArrowUpDown } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useNetworkStatus } from '@/hooks/use-network';
+import { Button } from '@/components/ui/button';
+import { useNetworkStatus, useFailoverConfig } from '@/hooks/use-network';
 import type { NetworkInterface } from '@shared/index';
-
-type WanSource = 'ethernet' | 'wifi' | 'usb' | 'none';
-
-interface WanSourceInfo {
-  readonly source: WanSource;
-  readonly label: string;
-  readonly icon: typeof Cable;
-  readonly iface?: NetworkInterface;
-}
 
 function detectWanSource(
   wan: NetworkInterface | null | undefined,
   interfaces: readonly NetworkInterface[] | undefined,
+  activeFailoverInterface: string | null | undefined,
 ): WanSourceInfo {
+  if (activeFailoverInterface && interfaces) {
+    const failoverIface = interfaces.find(iface => iface.name === activeFailoverInterface && iface.is_up);
+    if (failoverIface) {
+      if (failoverIface.type === 'usb') return { source: 'usb', label: 'USB Tether', icon: Usb, iface: failoverIface };
+      if (failoverIface.type === 'wifi') return { source: 'wifi', label: 'WiFi', icon: Wifi, iface: failoverIface };
+      return { source: 'ethernet', label: 'Ethernet', icon: Cable, iface: failoverIface };
+    }
+  }
+
   // Check the primary WAN interface first
   if (wan?.is_up) {
     if (wan.type === 'usb') return { source: 'usb', label: 'USB Tether', icon: Usb, iface: wan };
@@ -41,8 +43,9 @@ function detectWanSource(
 
 export function WanSourceCard() {
   const { data: network, isLoading } = useNetworkStatus();
+  const { data: failover, isLoading: failoverLoading } = useFailoverConfig();
 
-  if (isLoading) {
+  if (isLoading || failoverLoading) {
     return (
       <Card>
         <CardHeader>
@@ -56,28 +59,45 @@ export function WanSourceCard() {
     );
   }
 
-  const info = detectWanSource(network?.wan, network?.interfaces);
+  const activeFailoverInterface = (failover?.enabled && failover?.service_installed) ? failover?.active_interface : null;
+  const info = detectWanSource(network?.wan, network?.interfaces, activeFailoverInterface);
   const Icon = info.icon;
   const isActive = info.source !== 'none';
+  const isFailoverEnabled = failover?.enabled && failover?.service_installed;
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">WAN Source</CardTitle>
+        <div className="flex items-center gap-2">
+          <CardTitle className="text-sm font-medium">WAN Source</CardTitle>
+          {isFailoverEnabled && (
+            <Badge variant="outline" className="text-xs">
+              <ArrowUpDown className="mr-1 h-3 w-3" />
+              Automatic failover
+            </Badge>
+          )}
+        </div>
         <Icon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
-        <div className="flex items-center gap-2">
-          <div className={`h-2.5 w-2.5 rounded-full ${isActive ? 'bg-green-500' : 'bg-red-500'}`} />
-          <Badge variant={isActive ? 'success' : 'destructive'}>{info.label}</Badge>
-        </div>
-        {info.iface && (
-          <div className="mt-3 space-y-1 text-sm text-gray-600 dark:text-gray-400">
-            <div>Interface: {info.iface.name}</div>
-            {info.iface.ip_address && <div>IP: {info.iface.ip_address}</div>}
-            {info.iface.gateway && <div>Gateway: {info.iface.gateway}</div>}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className={`h-2.5 w-2.5 rounded-full ${isActive ? 'bg-green-500' : 'bg-red-500'}`} />
+            <Badge variant={isActive ? 'success' : 'destructive'}>{info.label}</Badge>
           </div>
-        )}
+          {failover?.service_installed && !failover?.enabled && (
+            <Button size="sm" variant="outline" className="w-full">
+              Configure failover
+            </Button>
+          )}
+          {info.iface && (
+            <div className="space-y-1 text-sm text-gray-600 dark:text-gray-400">
+              <div>Interface: {info.iface.name}</div>
+              {info.iface.ip_address && <div>IP: {info.iface.ip_address}</div>}
+              {info.iface.gateway && <div>Gateway: {info.iface.gateway}</div>}
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Backend:
- Add 30s failback hold-down to prevent interface flapping
- Track candidate online timestamps for hold-down
- Rewrite computeActiveInterface with stable logic
- Add tests (4 subtests): failover, hold-down, failback, selection

Frontend:
- Dashboard WAN card shows failover badge
- Display failover active uplink when available
- Add link to Network > Advanced config

Docs:
- Architecture §5.1: Multi-WAN failover invariant
- failover-decisions.md: design decisions and deferred items
- failover-verification.md: 7 test scenarios
- Update connection-failover.md Phase 0 (decisions locked)
- Clear tasks_open.md 2.7 failover items

Closes connection failover Priority #1