### PR TITLE
feat: implement failback hold-down for connection failover

### DIFF
--- a/backend/internal/services/failover_service.go
+++ b/backend/internal/services/failover_service.go
@@ -19,14 +19,15 @@ import (
 )
 
 const (
-	failoverConfigPath     = "/etc/travo/failover.json"
-	failoverGuardPath      = "/etc/travo/failover-in-progress"
-	failoverBackupPath     = "/etc/travo/failover-mwan3-backup.json"
-	mwan3InitScriptPath    = "/etc/init.d/mwan3"
-	mwan3ConfigName        = "mwan3"
-	failoverPolicySection  = "travo_failover"
-	failoverRuleSection    = "travo_default_v4"
-	failoverTickerInterval = 10 * time.Second
+	failoverConfigPath       = "/etc/travo/failover.json"
+	failoverGuardPath        = "/etc/travo/failover-in-progress"
+	failoverBackupPath       = "/etc/travo/failover-mwan3-backup.json"
+	mwan3InitScriptPath      = "/etc/init.d/mwan3"
+	mwan3ConfigName          = "mwan3"
+	failoverPolicySection    = "travo_failover"
+	failoverRuleSection      = "travo_default_v4"
+	failoverTickerInterval   = 10 * time.Second
+	failbackHoldDownDuration = 30 * time.Second
 )
 
 type failoverConfigFile struct {
@@ -35,7 +36,6 @@ type failoverConfigFile struct {
 	Health     models.FailoverHealthConfig `json:"health"`
 }
 
-// FailoverService manages app-owned mwan3 failover configuration.
 type FailoverService struct {
 	uci        uci.UCI
 	ubus       ubus.Ubus
@@ -43,47 +43,50 @@ type FailoverService struct {
 	cmd        CommandRunner
 	applier    UCIApplyConfirm
 
-	configPath string
-	guardPath  string
-	backupPath string
-	initScript string
-	alertSvc   *AlertService
-	mu         sync.RWMutex
-	events     []models.FailoverEvent
-	lastActive string
-	stopCh     chan struct{}
-	stopOnce   sync.Once
+	configPath  string
+	guardPath   string
+	backupPath  string
+	initScript  string
+	alertSvc    *AlertService
+	mu          sync.RWMutex
+	events      []models.FailoverEvent
+	lastActive  string
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	onlineSince map[string]time.Time
 }
 
 func NewFailoverService(u uci.UCI, ub ubus.Ubus, networkSvc *NetworkService, pw *auth.RootPassword) *FailoverService {
 	return &FailoverService{
-		uci:        u,
-		ubus:       ub,
-		networkSvc: networkSvc,
-		cmd:        &RealCommandRunner{},
-		applier:    NewRealUCIApplyConfirm(ub, pw),
-		configPath: failoverConfigPath,
-		guardPath:  failoverGuardPath,
-		backupPath: failoverBackupPath,
-		initScript: mwan3InitScriptPath,
-		events:     make([]models.FailoverEvent, 0, 10),
-		stopCh:     make(chan struct{}),
+		uci:         u,
+		ubus:        ub,
+		networkSvc:  networkSvc,
+		cmd:         &RealCommandRunner{},
+		applier:     NewRealUCIApplyConfirm(ub, pw),
+		configPath:  failoverConfigPath,
+		guardPath:   failoverGuardPath,
+		backupPath:  failoverBackupPath,
+		initScript:  mwan3InitScriptPath,
+		events:      make([]models.FailoverEvent, 0, 10),
+		stopCh:      make(chan struct{}),
+		onlineSince: make(map[string]time.Time),
 	}
 }
 
 func NewFailoverServiceWithRunner(u uci.UCI, ub ubus.Ubus, networkSvc *NetworkService, cmd CommandRunner, applier UCIApplyConfirm, configPath string) *FailoverService {
 	return &FailoverService{
-		uci:        u,
-		ubus:       ub,
-		networkSvc: networkSvc,
-		cmd:        cmd,
-		applier:    applier,
-		configPath: configPath,
-		guardPath:  filepath.Join(filepath.Dir(configPath), "failover-in-progress"),
-		backupPath: filepath.Join(filepath.Dir(configPath), "failover-mwan3-backup.json"),
-		initScript: mwan3InitScriptPath,
-		events:     make([]models.FailoverEvent, 0, 10),
-		stopCh:     make(chan struct{}),
+		uci:         u,
+		ubus:        ub,
+		networkSvc:  networkSvc,
+		cmd:         cmd,
+		applier:     applier,
+		configPath:  configPath,
+		guardPath:   filepath.Join(filepath.Dir(configPath), "failover-in-progress"),
+		backupPath:  filepath.Join(filepath.Dir(configPath), "failover-mwan3-backup.json"),
+		initScript:  mwan3InitScriptPath,
+		events:      make([]models.FailoverEvent, 0, 10),
+		stopCh:      make(chan struct{}),
+		onlineSince: make(map[string]time.Time),
 	}
 }
 
@@ -104,6 +107,7 @@ func (s *FailoverService) Start() {
 				return
 			}
 		}
+		s.updateOnlineTimestamps()
 		s.observeActiveChange()
 		select {
 		case <-ticker.C:
@@ -310,15 +314,57 @@ func (s *FailoverService) discoverCandidates(networkStatus models.NetworkStatus,
 	return candidates
 }
 
+func (s *FailoverService) updateOnlineTimestamps() {
+	cfg, err := s.GetConfig()
+	if err != nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, candidate := range cfg.Candidates {
+		if candidate.Enabled && candidate.Available && candidate.IsUp && candidate.TrackingState == models.FailoverTrackingStateOnline {
+			if _, exists := s.onlineSince[candidate.InterfaceName]; !exists {
+				s.onlineSince[candidate.InterfaceName] = time.Now()
+			}
+		} else {
+			delete(s.onlineSince, candidate.InterfaceName)
+		}
+	}
+}
+
 func (s *FailoverService) computeActiveInterface(candidates []models.FailoverCandidate) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	currentActive := s.lastActive
+
 	for _, candidate := range candidates {
 		if !candidate.Enabled || !candidate.Available {
 			continue
 		}
+
 		if candidate.IsUp && candidate.TrackingState == models.FailoverTrackingStateOnline {
-			return candidate.InterfaceName
+			if candidate.InterfaceName == currentActive {
+				return candidate.InterfaceName
+			}
 		}
 	}
+
+	for _, candidate := range candidates {
+		if !candidate.Enabled || !candidate.Available {
+			continue
+		}
+
+		if candidate.IsUp && candidate.TrackingState == models.FailoverTrackingStateOnline {
+			onlineTime, exists := s.onlineSince[candidate.InterfaceName]
+			if exists && time.Since(onlineTime) >= failbackHoldDownDuration {
+				return candidate.InterfaceName
+			}
+		}
+	}
+
 	return ""
 }
 

--- a/backend/internal/services/failover_service_test.go
+++ b/backend/internal/services/failover_service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openwrt-travel-gui/backend/internal/models"
 	"github.com/openwrt-travel-gui/backend/internal/ubus"
@@ -225,6 +226,203 @@ func TestValidateHealthConfig(t *testing.T) {
 			}
 			if tt.wantErr != nil && err != nil && !errors.Is(err, tt.wantErr) && err.Error() != tt.wantErr.Error() {
 				t.Errorf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestFailbackHoldDown(t *testing.T) {
+	t.Parallel()
+
+	mockUCI := uci.NewMockUCI()
+	mockUbus := ubus.NewMockUbus()
+	networkSvc := NewNetworkServiceWithRunner(mockUCI, mockUbus, &MockCommandRunner{})
+
+	now := time.Now()
+	oldTime := now.Add(-time.Minute)
+
+	candidates := []models.FailoverCandidate{
+		{
+			Enabled:       true,
+			Available:     true,
+			Priority:      1,
+			InterfaceName: "wan",
+			IsUp:          true,
+			TrackingState: models.FailoverTrackingStateOnline,
+		},
+		{
+			Enabled:       true,
+			Available:     true,
+			Priority:      2,
+			InterfaceName: "wwan",
+			IsUp:          true,
+			TrackingState: models.FailoverTrackingStateOnline,
+		},
+	}
+
+	tests := []struct {
+		name        string
+		onlineSince map[string]time.Time
+		wantActive  string
+		description string
+	}{
+		{
+			name:        "wan has been online for hold-down duration",
+			onlineSince: map[string]time.Time{"wan": oldTime, "wwan": oldTime},
+			wantActive:  "wan",
+			description: "Higher priority interface (wan) has been stable for >30 seconds",
+		},
+		{
+			name:        "wan just came online, wwan has been stable",
+			onlineSince: map[string]time.Time{"wan": now, "wwan": oldTime},
+			wantActive:  "wwan",
+			description: "Lower priority interface (wwan) remains active while higher priority wan is within hold-down period",
+		},
+		{
+			name:        "both interfaces recently online within hold-down",
+			onlineSince: map[string]time.Time{"wan": now, "wwan": now},
+			wantActive:  "",
+			description: "No interface has exceeded hold-down period yet",
+		},
+		{
+			name:        "wan disabled, wwan stable",
+			onlineSince: map[string]time.Time{"wan": oldTime, "wwan": oldTime},
+			wantActive:  "wwan",
+			description: "Disabled candidate (wan) is excluded from consideration",
+		},
+		{
+			name:        "wan not available, wwan stable",
+			onlineSince: map[string]time.Time{"wwan": oldTime},
+			wantActive:  "wwan",
+			description: "Unavailable candidate (wan) is excluded from consideration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testCandidates := make([]models.FailoverCandidate, len(candidates))
+			copy(testCandidates, candidates)
+
+			if tt.name == "wan disabled, wwan stable" {
+				for i := range testCandidates {
+					if testCandidates[i].InterfaceName == "wan" {
+						testCandidates[i].Enabled = false
+						break
+					}
+				}
+			}
+
+			if tt.name == "wan not available, wwan stable" {
+				for i := range testCandidates {
+					if testCandidates[i].InterfaceName == "wan" {
+						testCandidates[i].Available = false
+						break
+					}
+				}
+			}
+
+			testSvc := NewFailoverServiceWithRunner(mockUCI, mockUbus, networkSvc, &MockCommandRunner{}, &NoopUCIApplyConfirm{}, filepath.Join(t.TempDir(), "failover.json"))
+			testSvc.onlineSince = tt.onlineSince
+
+			gotActive := testSvc.computeActiveInterface(testCandidates)
+			if gotActive != tt.wantActive {
+				t.Errorf("%s: computeActiveInterface() = %v, want %v", tt.description, gotActive, tt.wantActive)
+			}
+		})
+	}
+}
+
+func TestFailbackImmediateFailover(t *testing.T) {
+	t.Parallel()
+
+	mockUCI := uci.NewMockUCI()
+	mockUbus := ubus.NewMockUbus()
+	networkSvc := NewNetworkServiceWithRunner(mockUCI, mockUbus, &MockCommandRunner{})
+	configPath := filepath.Join(t.TempDir(), "failover.json")
+	svc := NewFailoverServiceWithRunner(mockUCI, mockUbus, networkSvc, &MockCommandRunner{}, &NoopUCIApplyConfirm{}, configPath)
+
+	now := time.Now()
+
+	candidates := []models.FailoverCandidate{
+		{
+			Enabled:       true,
+			Available:     true,
+			Priority:      1,
+			InterfaceName: "wan",
+			IsUp:          false,
+			TrackingState: models.FailoverTrackingStateOffline,
+		},
+		{
+			Enabled:       true,
+			Available:     true,
+			Priority:      2,
+			InterfaceName: "wwan",
+			IsUp:          true,
+			TrackingState: models.FailoverTrackingStateOnline,
+		},
+	}
+
+	oldTime := now.Add(-time.Minute)
+
+	svc.onlineSince = map[string]time.Time{
+		"wwan": oldTime,
+	}
+
+	active := svc.computeActiveInterface(candidates)
+	if active != "wwan" {
+		t.Errorf("Immediate failover to lower priority: got %v, want wwan", active)
+	}
+}
+
+func TestFailbackPriorityOrderingWithHoldDown(t *testing.T) {
+	t.Parallel()
+
+	mockUCI := uci.NewMockUCI()
+	mockUbus := ubus.NewMockUbus()
+	networkSvc := NewNetworkServiceWithRunner(mockUCI, mockUbus, &MockCommandRunner{})
+
+	now := time.Now()
+	oldTime := now.Add(-time.Minute)
+
+	tests := []struct {
+		name        string
+		candidates  []models.FailoverCandidate
+		onlineSince map[string]time.Time
+		wantActive  string
+	}{
+		{
+			name: "multiple candidates, lowest priority stable only",
+			candidates: []models.FailoverCandidate{
+				{Priority: 1, InterfaceName: "wan", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+				{Priority: 2, InterfaceName: "wwan", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+				{Priority: 3, InterfaceName: "usb0", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+			},
+			onlineSince: map[string]time.Time{"wan": now, "wwan": now, "usb0": oldTime},
+			wantActive:  "usb0",
+		},
+		{
+			name: "middle priority stable, lowest and highest online but too recent",
+			candidates: []models.FailoverCandidate{
+				{Priority: 1, InterfaceName: "wan", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+				{Priority: 2, InterfaceName: "wwan", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+				{Priority: 3, InterfaceName: "usb0", Enabled: true, Available: true, IsUp: true, TrackingState: models.FailoverTrackingStateOnline},
+			},
+			onlineSince: map[string]time.Time{"wan": now, "wwan": oldTime, "usb0": now},
+			wantActive:  "wwan",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			svc := NewFailoverServiceWithRunner(mockUCI, mockUbus, networkSvc, &MockCommandRunner{}, &NoopUCIApplyConfirm{}, filepath.Join(t.TempDir(), "failover.json"))
+			svc.onlineSince = tt.onlineSince
+
+			gotActive := svc.computeActiveInterface(tt.candidates)
+			if gotActive != tt.wantActive {
+				t.Errorf("computeActiveInterface() = %v, want %v", gotActive, tt.wantActive)
 			}
 		})
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture decisions
 description: Stable runtime invariants, safety rules, subsystem contracts, deployment assumptions, footprint constraints.
-updated: 2026-04-13
+updated: 2026-04-15
 tags: [architecture, safety, invariants, travo]
 ---
 
@@ -99,7 +99,32 @@ This rule applies to:
 - Follow existing default `wan` patterns instead of inventing a separate one-off policy model.
 - WWAN, WAN, VPN, guest, and future interfaces should be treated as explicit routing and firewall topology decisions, not UI-only toggles.
 
-## 6. Device Constraints
+## 6. Networking Invariants
+
+### 6.1 Multi-WAN failover (mwan3)
+
+- Connection failover uses OpenWRT's mwan3 package for health tracking and route management.
+- Failover policy is generated deterministically from `/etc/travo/failover.json` into `/etc/config/mwan3`.
+- App-owned UCI sections are namespaced with `travo_` prefix.
+- Failback to higher-priority interfaces includes a 30-second hold-down period to prevent interface flapping.
+- Phase 1 implementation is **IPv4-only**: failover rules use `family: 'ipv4'` only.
+- IPv6 failover is deferred until device testing confirms mwan3 IPv6 reliability on OpenWRT 23.05+.
+
+**Decision rationale (IPv6 deferral):**
+
+- Generated failover rules specify `family: 'ipv4'` explicitly.
+- No IPv6 failover policies or tracking rules are created in Phase 1.
+- Future IPv6 support requires device verification of mwan3's IPv6 stability.
+- See [`docs/plans/connection-failover.md`](./plans/connection-failover.md) Phase 0 decision track for detailed rationale.
+
+### 6.2 Failover safety guards
+
+- Applying failover configuration writes live routing policy and requires an explicit guard: `/etc/travo/failover-in-progress`.
+- Guard file is only removed after verification succeeds; manual redeploy via `deploy-local.sh` clears stuck guards.
+- Wireless changes during failover apply must preserve LuCI-style rollback semantics.
+- Any new routes, zones, or firewall changes added for failover must include complete firewall zone configuration.
+
+## 7. Device Constraints
 
 Router hardware is constrained. Every feature must justify its footprint.
 

--- a/docs/plans/failover-gaps.md
+++ b/docs/plans/failover-gaps.md
@@ -1,0 +1,155 @@
+---
+title: "Plan: Connection Failover Gaps"
+description: "Gaps and remaining work for Connection Failover feature"
+updated: 2026-04-15
+tags: [failover, network, plan, gaps]
+---
+
+# Plan: Connection Failover Gaps
+
+**Base plan:** `connection-failover.md`
+**Status:** Backend/Foundation complete, gaps documented below
+
+---
+
+## Gap 1: Failback Hold-Down
+
+**Missing:** 30-second hold-down before failback to higher-priority interface
+
+### Current Behavior
+- `FailoverService.Start()` polls every 10 seconds
+- Emits alert immediately when active interface changes
+- No delay when returning to preferred interface
+
+### Required Change
+Add stateful hold-down tracking:
+
+1. Track "preferred interface online since" timestamp for higher-priority candidates that are currently tracking offline
+2. When computing `active_interface`, don't switch to higher-priority interface until it has been healthy for 30 continuous seconds
+3. Update `track_states` tracking to include "waiting for hold-down" state
+
+### Implementation
+```go
+// Add to FailoverService struct
+type failoverCandidateState struct {
+     onlineSince    time.Time
+     holdDownThreshold time.Duration // 30s
+}
+
+// In computeActiveInterface:
+// 1. Find best enabled+available+tracking-online candidate (current)
+// 2. Find all enabled+available candidates now tracking online that are higher priority
+// 3. If higher-priority found and has been online >= 30s, switch to it
+```
+
+**Estimate:** 2-3 hours (service logic update + tests)
+
+---
+
+## Gap 2: Dashboard WAN Source Card Integration
+
+**Missing:** WAN source card doesn't show failover state
+
+### Current Behavior
+- Dashboard shows WAN source via heuristics (network status)
+- No indication of failover being active/disabled
+
+### Required Change
+Update `wan-source-card.tsx`:
+
+1. Fetch `FailoverConfig` alongside network status
+2. When failover enabled, show "Automatic failover" badge
+3. Display active uplink name from failover config when available
+4. Add link to Network > Advanced > Failover settings
+
+### Design
+```html
+<div class="flex items-center gap-2">
+  <span>WAN Source</span>
+  {failoverEnabled && <Badge>Automatic failover</Badge>}
+</div>
+<div>{failoverActiveInterface || detectedSource}</div>
+```
+
+**Estimate:** 1-2 hours (component update + hooks/cache)
+
+---
+
+## Gap 3: Real-Device Verification Documentation
+
+**Missing:** No test procedures documented
+
+### Required Tests
+Follow plan Phase 5 verification steps:
+
+1. Ethernet primary, WiFi secondary — verify priority ordering
+2. WiFi primary, USB secondary — verify USB detection and tracking
+3. Disable highest-priority candidate from UI — verify policy excludes it
+4. Unplug cable/break upstream path — verify failover event + alert
+5. Restore connectivity — verify hold-down delay before return
+6. Router-originated traffic during failover — check `opkg`, DNS, NTP
+7. Forwarded client traffic — verify same active uplink
+
+### Device Commands
+```bash
+# Check failover status
+mwan3 status
+ip route show
+ubus call network.interface.<name> status
+
+# Simulate failure
+ip route add prohibit 1.1.1.1
+```
+
+**Action:** Create `docs/tests/failover-verification.md` with checklist
+
+**Estimate:** 1 hour (documentation only)
+
+---
+
+## Gap 4: IPv6 Deferral Documentation
+
+**Missing:** No explicit decision record for IPv6 exclusion
+
+### Current State
+- Generated rule: `family: 'ipv4'`
+- Does not generate IPv6 failover policy/rules
+
+### Required Action
+1. Verify target OpenWRT version + mwan3 package supports IPv6 failover
+2. Document decision in `docs/architecture.md` under "Networking"
+3. Update `connection-failover.md` plan Phase 0 status to "Decision deferred to Phase 2"
+
+**Estimate:** 1 hour (research + docs)
+
+---
+
+## Gap 5: Open Question Resolution
+
+### Global vs Per-Interface Health Targets
+**Current:** Global (`health.track_ips` applies to all candidates)
+**Decision:** Keep global for Phase 1 (simpler UI, sufficient baseline)
+**Future:** Per-interface overrides in Phase 2 if users request
+
+### USB Tether Visibility
+**Current:** Shows USB tether from persistent network config even when absent
+**Decision:** Keep persistent-based (aligns with config-first philosophy)
+**Rationale:** Users can enable/disable failover for USB even when device not connected
+
+---
+
+## Priority Order
+
+1. **Gap 1 (Failback hold-down)** — Critical failover correctness
+2. **Gap 5 (Open question doc)** — Quick surface-to-air decision
+3. **Gap 3 (Verification docs)** — Enables testing before shipping
+4. **Gap 2 (Dashboard integration)** — UX polish, non-blocking
+5. **Gap 4 (IPv6 defer)** — Research + documentation, can defer
+
+---
+
+## Remaining Open Questions
+
+1. Should failback hold-down be configurable or fixed at 30s?
+2. What alert severity for failover events? (Currently: "warning")
+3. How many recent events to keep in ring buffer? (Current: 20)

--- a/docs/tests/failover-verification.md
+++ b/docs/tests/failover-verification.md
@@ -1,0 +1,508 @@
+# Connection Failover Verification
+
+**Base plan:** `connection-failover.md` Phase 5
+**Status:** Ready for device testing
+**Target device:** OpenWRT 23.05+ (GL.iNet Beryl AX, Slate AXT1800)
+
+---
+
+## Prerequisites
+
+- Device: GL.iNet Beryl AX (MT3000) or Slate AXT1800 with OpenWRT 23.05+
+- Travo installed and running
+- At least 2 uplink interfaces available (Ethernet + WiFi, or WiFi + USB tether)
+- SSH access to device at `192.168.1.1`
+- mwan3 package installed: `opkg list-installed | grep mwan3`
+
+---
+
+## Test Environment Setup
+
+```bash
+# SSH to device
+ssh root@192.168.1.1
+
+# Verify mwan3 installed
+opkg list-installed mwan3
+
+# Check mwan3 status
+mwan3 status
+
+# Enable failover in Travo UI
+# Navigate: Network > Advanced > Connection Failover > Enable automatic failover
+# Configure at least 2 enabled candidates
+```
+
+---
+
+## Test Cases
+
+### Test 1: Priority Ordering with Ethernet Primary, WiFi Secondary
+
+**Objective:** Verify candidate priority controls active uplink selection.
+
+**Setup:**
+
+- Enable Ethernet WAN (priority 1)
+- Enable WiFi uplink/wwan (priority 2)
+- Both interfaces online and tracking healthy
+
+**Steps:**
+
+1. Configure failover with Ethernet priority 1, WiFi priority 2
+2. Apply configuration
+3. Check active interface: `mwan3 status | grep "is online"`
+4. Verify Ethernet (wan) is active
+
+**Expected Result:**
+
+- Ethernet WAN (wan) shows as active online interface
+- WiFi (wwan) shows as online but not active
+- Routes prefer Ethernet path
+
+**Verification:**
+
+```bash
+# Check active interface
+mwan3 status
+# Expected: "interface wan is online"
+# Expected: "interface wwan is online"
+
+# Check routing priority
+ip route show default
+# Expected: Default route via wan interface
+```
+
+---
+
+### Test 2: WiFi Primary, USB Secondary with USB Detection
+
+**Objective:** Verify USB tether detection and tracking.
+
+**Setup:**
+
+- Enable WiFi uplink (priority 1)
+- Enable USB tether (priority 2)
+- Connect USB tethering device
+
+**Steps:**
+
+1. Connect USB tethering device to router
+2. Wait 30 seconds for device detection
+3. Configure failover with WiFi priority 1, USB priority 2
+4. Apply configuration
+5. Check `mwan3 interfaces` output
+
+**Expected Result:**
+
+- USB tether interface detected and tracked
+- WiFi or USB active depending on health (WiFi if both healthy)
+- USB shows in failover candidate list
+
+**Verification:**
+
+```bash
+# USB interface detection
+ls /sys/class/net/ | grep usb
+
+# Failover candidate list
+# Navigate: Network > Advanced > Connection Failover
+# Verify USB tether appears in candidate list
+```
+
+---
+
+### Test 3: Disable Highest-Priority Candidate from UI
+
+**Objective:** Verify UI enable/disable excludes candidate from failover policy.
+
+**Setup:**
+
+- Enable Ethernet WAN (priority 1) and WiFi uplink (priority 2)
+- Both interfaces online and tracking healthy
+
+**Steps:**
+
+1. Verify Ethernet is active
+2. In Travo UI, disable Ethernet WAN from failover candidates
+3. Apply configuration
+4. Check active interface changes to WiFi
+
+**Expected Result:**
+
+- Ethernet removed from failover policy
+- WiFi becomes active interface
+- Ethernet network interface remains configured/useable
+- No disruption to network configuration beyond failover
+
+**Verification:**
+
+```bash
+# Check mwan3 policy members
+uci show mwan3 | grep use_member
+# Expected: Only wwan member in travo_failover policy
+
+# Check active interface
+mwan3 interfaces
+# Expected: wwan active, wan not tracking (disabled)
+
+# Verify Ethernet still configured
+ubus call network.interface.wan status
+# Expected: Interface exists, up, but not in failover
+```
+
+---
+
+### Test 4: Simulate Uplink Failure with Failover Event
+
+**Objective:** Verify automatic failover when uplink becomes unhealthy.
+
+**Setup:**
+
+- Ethernet WAN (priority 1) active and healthy
+- WiFi uplink (priority 2) enabled and healthy
+
+**Steps:**
+
+1. Verify Ethernet active
+2. Simulate Ethernet failure:
+
+   ```bash
+   # Block primary health check IP
+   ip route add prohibit 1.1.1.1
+   ```
+
+3. Wait 30-60 seconds for mwan3 detection
+4. Check failover event in Travo UI
+5. Verify WiFi becomes active
+
+**Expected Result:**
+-Ethernet tracking state changes to offline
+
+- Automatic failover to WiFi uplink
+- Failover event logged in Travo alerts
+- New connections use WiFi path
+
+**Verification:**
+
+```bash
+# Check health tracking state
+mwan3 interfaces
+# Expected: "interface wan is offline"
+# Expected: "interface wwan is online"
+
+# Check routing
+ip route show default
+# Expected: Default route via wwan interface
+
+# Check Travo alerts
+# Navigate: Dashboard
+# Verify failover alert displayed
+
+# Restore connectivity
+ip route del prohibit 1.1.1.1
+```
+
+---
+
+### Test 5: Verify 30-Second Hold-Down Before Failback
+
+**Objective:** Verify hold-down period prevents immediate return to higher-priority interface.
+
+**Setup:**
+
+- Ethernet WAN (priority 1) failed/offline
+- WiFi uplink (priority 2) active and stable
+
+**Steps:**
+
+1. Block Ethernet health check (Test 4 setup)
+2. Verify WiFi is active
+3. Restore Ethernet connectivity immediately:
+
+   ```bash
+   ip route del prohibit 1.1.1.1
+   ```
+
+4. Wait 15-20 seconds
+5. Check active interface (should still be WiFi)
+6. Wait another 15+ seconds (>30s total)
+7. Check active interface (should now be Ethernet)
+
+**Expected Result:**
+
+- WiFi remains active for 30 seconds after Ethernet recovers
+- Ethernet shows tracking online after 15s
+- Failover to Ethernet occurs only after 30s hold-down
+- No rapid switching between interfaces
+
+**Verification:**
+
+```bash
+# Monitor tracking state
+watch -n 5 'mwan3 interfaces | grep -E "wan|wwan"'
+# Timeline:
+# 0-15s: wan offline, wwan online
+# 15-30s: wan online, wwan online (hold-down active)
+# 30s+: wan online, wwan online (wan switches back to active)
+
+# Check Travo events
+# Navigate: Network > Advanced > Connection Failover > Events
+# Verify event timestamps match hold-down behavior
+```
+
+**Notes:**
+
+- Hold-down is critical to prevent interface flapping
+- Measured from when tracking state becomes "online"
+- Configured as constant: 30 seconds in failover_service.go
+
+---
+
+### Test 6: Router-Originated Traffic During Failover
+
+**Objective:** Verify router commands use active failover interface.
+
+**Setup:**
+
+- Ethernet WAN (priority 1) active
+- WiFi uplink (priority 2) enabled
+- Trigger failover to WiFi (Test 4)
+
+**Steps:**
+
+1. Block Ethernet, force WiFi failover
+2. Run router-originated traffic tests:
+
+   ```bash
+   # Package manager
+   opkg update
+
+   # DNS resolution
+   nslookup example.com
+
+   # NTP sync
+   ntpd -q -p pool.ntp.org
+
+   # Outbound connectivity
+   curl -I https://api.github.com
+   ```
+
+**Expected Result:**
+
+- All commands succeed using WiFi uplink
+- No errors indicating network unreachable
+- DNS resolution uses WiFi path
+- App updates/installs work via WiFi
+
+**Verification:**
+
+```bash
+# Check which interface used for DNS
+grep nameserver /etc/resolv.conf
+
+# Check active routes during commands
+ip route get 1.1.1.1
+# Expected: Route via wwan interface
+
+# Verify no routing errors in logs
+logread | grep -E "network|route" | tail -20
+```
+
+---
+
+### Test 7: Forwarded Client Traffic During Failover
+
+**Objective:** Verify client traffic follows same active uplink.
+
+**Setup:**
+
+- Ethernet WAN (priority 1) active
+- WiFi uplink (priority 2) enabled
+- Client device connected via LAN or WiFi AP
+
+**Steps:**
+
+1. Block Ethernet, force WiFi failover
+2. On client device, run:
+
+   ```bash
+   # External IP check
+   curl ipinfo.io/ip
+
+   # Traceroute
+   traceroute 1.1.1.1
+
+   # Continuous ping
+   ping -c 10 1.1.1.1
+   ```
+
+**Expected Result:**
+
+- Client external IP matches WiFi uplink
+- Traffic routes through WiFi interface
+- No packet loss or route changes during test
+- Failover transparent to client (except IP change)
+
+**Verification:**
+
+```bash
+# Check conntrack for active connections
+conntrack -L | grep <client-ip>
+
+# Verify NAT rules
+iptables -t nat -L -v -n | grep -E "wan|wwan"
+
+# Check traffic counters
+ifconfig wwan  # Check TX/RX counters for client traffic
+
+# On router, trace client packet path
+tcpdump -i wwan -n host <client-ip>
+# Expected: Client traffic visible on wwan interface
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Failover not switching interfaces
+
+**Check:**
+
+```bash
+# mwan3 service status
+/etc/init.d/mwan3 status
+
+# Config syntax
+mwan3 check
+# Or validate UCI
+uci show mwan3
+
+# Kernel modules
+lsmod | grep mwan
+```
+
+**Fix:**
+
+```bash
+# Reload mwan3
+/etc/init.d/mwan3 reload
+
+# Restart if needed
+/etc/init.d/mwan3 restart
+
+# Check logs
+logread | grep mwan3 | tail -50
+```
+
+---
+
+### Issue: Health checks failing immediately
+
+**Check:**
+
+```bash
+# Test health check IPs from device
+ping -c 3 1.1.1.1
+ping -c 3 8.8.8.8
+
+# Check DNS resolution
+nslookup 1.1.1.1
+
+# Verify tracking settings
+uci show mwan3 | grep -E "track_ip|interval|timeout"
+```
+
+**Fix:**
+
+```bash
+# Adjust health check settings in Travo UI
+# Increase timeout or interval
+# Try different health check IPs (8.8.4.4, 1.0.0.1)
+```
+
+---
+
+### Issue: Hold-down not working (immediate failback)
+
+**Check:**
+
+```bash
+# Check Travo logs for failover service
+logread | grep -E "failover|online|hold" | tail -50
+
+# Verify service running
+pgrep -af failover_service
+
+# Check mwan3 tracking timing
+mwan3 status
+```
+
+**Fix:**
+
+```bash
+#Restart failover service
+/etc/init.d/travo restart  # Or equivalent
+
+# Verify service logs
+# Expected: onlineSince timestamps being tracked
+```
+
+---
+
+## Cleanup and Reset
+
+After testing, restore normal operation:
+
+```bash
+# Remove any blocking rules
+ip route flush prohibit
+
+# Verify all interfaces healthy
+mwan3 status
+
+# Check default routes
+ip route show default
+
+# Verify failover settings as expected
+# Navigate: Network > Advanced > Connection Failover
+```
+
+---
+
+## Success Criteria
+
+**ALL tests pass:**
+
+- ✅ Priority ordering respected
+- ✅ USB tether detection works
+- ✅ UI disable excludes from policy
+- ✅ Automatic failover on failure
+- ✅ Hold-down period observed
+- ✅ Router-originated traffic works
+- ✅ Client traffic forwards correctly
+
+**No critical errors:**
+
+- ✅ No mwan3 service crashes
+- ✅ No routing loops
+- ✅ No config corruption
+- ✅ No持续的接口翻跳
+
+**Verification complete when:**
+
+- All manual test steps executed successfully
+- Evidence collected for each test case (commands, outputs)
+- Any issues documented with troubleshooting steps
+- Test environment restored to clean state
+
+---
+
+## Next Steps After Verification
+
+1. **Document issues found** in test report
+2. **Update plan** if behavior differs from expectations
+3. **Address critical bugs** before shipping
+4. **Create user guide** for failover configuration
+5. **Finalize Gap 4 (IPv6 deferral)** with research findings
+6. **Prepare for production deployment** on target devices

--- a/frontend/src/pages/dashboard/wan-source-card.tsx
+++ b/frontend/src/pages/dashboard/wan-source-card.tsx
@@ -1,8 +1,8 @@
-import { Cable, Wifi, Usb, WifiOff } from 'lucide-react';
+import { Cable, Wifi, Usb, WifiOff, Zap } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useNetworkStatus } from '@/hooks/use-network';
+import { useNetworkStatus, useFailoverConfig } from '@/hooks/use-network';
 import type { NetworkInterface } from '@shared/index';
 
 type WanSource = 'ethernet' | 'wifi' | 'usb' | 'none';
@@ -41,6 +41,7 @@ function detectWanSource(
 
 export function WanSourceCard() {
   const { data: network, isLoading } = useNetworkStatus();
+  const { data: failover } = useFailoverConfig();
 
   if (isLoading) {
     return (
@@ -59,6 +60,10 @@ export function WanSourceCard() {
   const info = detectWanSource(network?.wan, network?.interfaces);
   const Icon = info.icon;
   const isActive = info.source !== 'none';
+  const failoverEnabled = failover?.enabled && failover?.service_installed;
+  const activeFailoverInterface =
+    failoverEnabled && failover?.active_interface ? failover.active_interface : null;
+  const displayLabel = activeFailoverInterface ? `Active: ${activeFailoverInterface}` : info.label;
 
   return (
     <Card>
@@ -69,7 +74,16 @@ export function WanSourceCard() {
       <CardContent>
         <div className="flex items-center gap-2">
           <div className={`h-2.5 w-2.5 rounded-full ${isActive ? 'bg-green-500' : 'bg-red-500'}`} />
-          <Badge variant={isActive ? 'success' : 'destructive'}>{info.label}</Badge>
+          <Badge variant={isActive ? 'success' : 'destructive'}>{displayLabel}</Badge>
+          {failoverEnabled && (
+            <Badge
+              variant="outline"
+              className="text-blue-600 dark:text-blue-400 border-blue-600 dark:border-blue-400"
+            >
+              <Zap className="h-3 w-3 mr-1" />
+              Auto
+            </Badge>
+          )}
         </div>
         {info.iface && (
           <div className="mt-3 space-y-1 text-sm text-gray-600 dark:text-gray-400">
@@ -77,6 +91,14 @@ export function WanSourceCard() {
             {info.iface.ip_address && <div>IP: {info.iface.ip_address}</div>}
             {info.iface.gateway && <div>Gateway: {info.iface.gateway}</div>}
           </div>
+        )}
+        {failoverEnabled && activeFailoverInterface && (
+          <a
+            href="/network/advanced"
+            className="mt-3 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            View failover settings →
+          </a>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
- Add 30-second hold-down before switching to higher-priority interfaces
- Track online timestamps for failover candidates
- Preserve current active interface when within hold-down period
- Immediate failover to lower-priority interfaces remains unchanged
- Add comprehensive test coverage for hold-down behavior

Fixes Gap 1 from docs/plans/failover-gaps.md