### PR TITLE
ci: harden workflows to pass zizmor audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -13,8 +15,12 @@ jobs:
   test-backend:
     name: Test Backend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -32,8 +38,12 @@ jobs:
   test-frontend:
     name: Test Frontend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
@@ -58,8 +68,12 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
@@ -90,8 +104,12 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     needs: [test-backend, test-frontend]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:

--- a/.github/workflows/race-detector.yml
+++ b/.github/workflows/race-detector.yml
@@ -3,12 +3,18 @@ name: Race Detector
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test-race:
     name: Test with Race Detector
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,14 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   build-and-release:
     name: Build (${{ matrix.arch }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -24,11 +25,13 @@ jobs:
             package_arch: x86_64
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: backend/go.mod
-          cache-dependency-path: backend/go.sum
+          cache: false
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
@@ -37,7 +40,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
-          cache: pnpm
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -56,9 +59,10 @@ jobs:
           CGO_ENABLED: '0'
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           go build \
-            -ldflags "-s -w -X main.Version=${{ steps.version.outputs.VERSION }}" \
+            -ldflags "-s -w -X main.Version=${VERSION}" \
             -o "../dist/travo" \
             ./cmd/server
 
@@ -84,10 +88,13 @@ jobs:
     name: Create Release
     needs: build-and-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -104,29 +111,35 @@ jobs:
         run: sha256sum * > SHA256SUMS
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
-        with:
-          generate_release_notes: true
-          files: artifacts/*
-          body: |
-            ## Quick Install (OpenWRT)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            artifacts/* \
+            --notes "$(cat <<EOF
+          ## Quick Install (OpenWRT)
 
-            ```sh
-            wget -O- https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | sh
-            ```
+          \`\`\`sh
+          wget -O- https://raw.githubusercontent.com/${REPOSITORY}/main/scripts/install.sh | sh
+          \`\`\`
 
-            Or install a specific version:
+          Or install a specific version:
 
-            ```sh
-            VERSION=${{ steps.version.outputs.VERSION }} \
-              wget -O- https://raw.githubusercontent.com/${{ github.repository }}/main/scripts/install.sh | sh
-            ```
+          \`\`\`sh
+          VERSION=${VERSION} \\
+            wget -O- https://raw.githubusercontent.com/${REPOSITORY}/main/scripts/install.sh | sh
+          \`\`\`
 
-            ## Downloads
+          ## Downloads
 
-            | Architecture | Install tarball |
-            |---|---|
-            | aarch64 (GL.iNet MT3000/AXT1800) | `travo_${{ steps.version.outputs.VERSION }}_aarch64_cortex-a53.tar.gz` |
-            | x86_64 | `travo_${{ steps.version.outputs.VERSION }}_x86_64.tar.gz` |
+          | Architecture | Install tarball |
+          |---|---|
+          | aarch64 (GL.iNet MT3000/AXT1800) | \`travo_${VERSION}_aarch64_cortex-a53.tar.gz\` |
+          | x86_64 | \`travo_${VERSION}_x86_64.tar.gz\` |
 
-            See [SHA256SUMS](SHA256SUMS) for checksums.
+          See [SHA256SUMS](SHA256SUMS) for checksums.
+          EOF
+          )"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: zizmor
+
+on:
+  pull_request:
+    paths: [.github/**]
+  push:
+    branches: [main]
+    paths: [.github/**]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
Scope permissions per job, disable release caches, fix template injection, and add zizmor CI gate.