### PR TITLE
fix(ui): full frontend consistency pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ test/integration/tmp/
 test/integration/wireguard-profiles/
 
 docs/.obsidian
+.worktrees/

--- a/docs/plans/2026-07-20-nested-cards-approach-a.md
+++ b/docs/plans/2026-07-20-nested-cards-approach-a.md
@@ -1,0 +1,24 @@
+---
+title: Nested cards and form chrome (Approach A)
+description: Equal-height WiFi cards, flatten nested panels, align form controls to shadcn-like rules.
+updated: 2026-07-20
+tags: [frontend, ux, cards, forms]
+---
+
+# Nested cards / form chrome — Approach A
+
+**Goal:** Fix reported WiFi/Network layout weirdness and apply shared inset pattern to same-family siblings; strip true Card-in-Card on Services.
+
+**Rules:** `docs/plans/_shadcn-ui-patterns.md` + audit `docs/plans/_ui-nested-cards-audit.md`.
+
+## Tasks
+
+1. Add shared `CardInset` (or `cn` helper class string) for nested regions — `rounded-md border border-gray-200 p-3 dark:border-white/10` and optional muted variant without competing shadow.
+2. Equal-height Current Connection / Saved Networks.
+3. Scan/Hidden button fit (wrap + shorter labels).
+4. Flatten Auto-reconnect, AP nested boxes, guest/MAC/schedule same pattern.
+5. DNS Add `h-10`; Diagnostics tab-bar style + Run `h-10`.
+6. Services: remove nested Card shadow (ServiceCard flat or `shadow-none`).
+7. Tests + deploy to 192.168.1.1.
+
+Worktree: `.worktrees/ui-consistency` branch `fix/ui-consistency`.

--- a/docs/plans/2026-07-20-ui-consistency.md
+++ b/docs/plans/2026-07-20-ui-consistency.md
@@ -99,10 +99,10 @@ tags: [frontend, ux, theming, consistency]
 **Files:**
 - `frontend/src/pages/dashboard/dashboard-page.tsx` (`SourceCard` + related slate-on-white)
 
-- [ ] Make SourceCard readable in light mode: either force dark surface (`bg-slate-900` both themes) OR map slate text to gray/slate with proper light/dark pairs
-- [ ] Prefer forcing dark card chrome for SourceCard (matches topology aesthetic) — set explicit `bg-slate-900 border-slate-700 text-slate-*` without relying on white Card default
-- [ ] Update dashboard tests if they assert classes
-- [ ] Commit: `fix(ui): fix dashboard source card light contrast`
+- [x] Make SourceCard readable in light mode: either force dark surface (`bg-slate-900` both themes) OR map slate text to gray/slate with proper light/dark pairs
+- [x] Prefer forcing dark card chrome for SourceCard (matches topology aesthetic) — set explicit `bg-slate-900 border-slate-700 text-slate-*` without relying on white Card default
+- [x] Update dashboard tests if they assert classes
+- [x] Commit: `fix(ui): fix dashboard source card light contrast`
 
 ---
 

--- a/docs/plans/2026-07-20-ui-consistency.md
+++ b/docs/plans/2026-07-20-ui-consistency.md
@@ -1,0 +1,197 @@
+---
+title: UI consistency pass
+description: Unify page shell, cards, loading/empty/error, labels, and status chrome across Travо frontend.
+updated: 2026-07-20
+tags: [frontend, ux, theming, consistency]
+---
+
+# UI Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Travо frontend UI/UX consistent across every page — shared card chrome, page rhythm, loading/empty/error patterns, form labels, and status badges — without changing product behavior.
+
+**Architecture:** Tighten design-system defaults in `frontend/src/components/ui/` first, then migrate call sites. Protected pages keep `AppShell`; page roots follow a documented spacing contract. Prefer existing primitives (`Skeleton`, `EmptyState`, `Badge`) over one-offs.
+
+**Tech Stack:** React + TypeScript + Vite + TailwindCSS v4, existing `components/ui/*`.
+
+## Global Constraints
+
+- Work only in worktree `/Users/marbaced/projects/raydak/travo/.worktrees/ui-consistency` on branch `fix/ui-consistency`.
+- Do not change backend, OpenAPI, or device scripts.
+- Follow `docs/ui-theming.md`: inherit body text; secondary copy uses `text-gray-500 dark:text-gray-400` (or both light/dark pairs); no light-only gray text on dual-theme surfaces.
+- Surgical diffs: no drive-by refactors unrelated to consistency.
+- TDD where behavior changes are testable; update existing frontend tests that assert class names/copy.
+- Commit after each task with Conventional Commits (`fix(ui):` / `feat(ui):` / `refactor(ui):`).
+- Run `cd frontend && pnpm test` (or targeted) after each task; before finish run top-level `make lint`, `make test`, `make build` from worktree root.
+- Do **not** remove Network Status “Connected Clients” table (product duplication OK); only align presentation with shared primitives.
+- Login/Setup stay outside AppShell (intentional).
+- Model for all subagents: `cursor-grok-4.5-high`.
+
+### Page content contract (normative)
+
+| Page type | Root class |
+|-----------|------------|
+| Default protected page | `space-y-6` |
+| Tabbed page (WiFi, Network) | `space-y-4` (tab bar tight) then panels `space-y-6` |
+| Never | Extra page-level `p-*` (AppShell already pads) |
+| Lazy suspense fallback | No extra `p-*` (shell already pads) |
+
+### Card contract (normative)
+
+- `CardTitle` default: `text-sm font-medium leading-none tracking-tight` + existing theme text colors (not `text-lg font-semibold`).
+- Remove redundant `className="text-sm font-medium"` overrides after default change (keep layout classes like `flex items-center gap-2`).
+- Exceptions allowed: Login hero title (`text-2xl`); Setup step titles that are not CardTitle.
+- Card structure: prefer `Card` → `CardHeader` → `CardTitle` → `CardContent`; do not invent alternate title typography on Card surfaces.
+
+### Feedback contract (normative)
+
+- **Loading:** `Skeleton` (or Spinner/`Loader2` only for in-button/submit busy). Kill `animate-pulse` placeholder blocks and plain `"Loading…"` text for card content.
+- **Empty:** `EmptyState` from `@/components/ui/empty-state`.
+- **Load/query errors in cards/pages:** shared `InlineError` (new) — red bordered box with message.
+- **Mutation success/failure:** keep `sonner` toasts where already used; do not convert toasts to InlineError or vice versa for the same interaction type.
+- **Status:** prefer shared `Badge` variants; dashboard SourceCard connection chip may stay custom but must be theme-safe (light + dark).
+
+### Label contract (normative)
+
+- New `Label` primitive: default `text-xs font-medium text-gray-500 dark:text-gray-400`.
+- Dense forms migrate to `<Label>` (or same classes). Login may keep `text-sm font-medium` via `Label` `className` override if needed for prominence.
+
+---
+
+## Task 1: Design-system primitives
+
+**Files:**
+- Modify: `frontend/src/components/ui/card.tsx` (`CardTitle` default)
+- Create: `frontend/src/components/ui/label.tsx`
+- Create: `frontend/src/components/ui/inline-error.tsx`
+- Create/modify tests under `frontend/src/components/ui/__tests__/` if present, else add minimal tests
+- Update: `docs/ui-theming.md` with Card/Label/feedback contracts (short)
+
+- [ ] Write/adjust unit tests for CardTitle default classes
+- [ ] Change `CardTitle` default to `text-sm font-medium …` (keep `text-gray-900 dark:text-white`)
+- [ ] Add `Label` forwardRef wrapping `<label>` with contract classes + `cn`
+- [ ] Add `InlineError` (`role="alert"`, `text-sm`, red border/bg pairs for light+dark)
+- [ ] Document contracts in `docs/ui-theming.md`
+- [ ] Commit: `feat(ui): tighten card title, label, inline-error primitives`
+
+---
+
+## Task 2: Page shell contract
+
+**Files:**
+- `frontend/src/pages/clients/clients-page.tsx` — drop extra `p-4`
+- `frontend/src/components/layout/lazy-page-boundary.tsx` — drop fallback `p-4 sm:p-6`
+- `frontend/src/pages/services/sqm-page.tsx` — wrap content in `space-y-6` when needed
+- Tabbed pages: confirm WiFi/Network roots stay `space-y-4`; other pages `space-y-6`
+- Update any tests asserting clients padding
+
+- [ ] Fix clients double padding
+- [ ] Fix lazy boundary double padding
+- [ ] Normalize SQM page root spacing
+- [ ] Grep for page roots with `p-4`/`p-6` under `pages/` and remove extras inside AppShell
+- [ ] Commit: `fix(ui): normalize page shell spacing`
+
+---
+
+## Task 3: Dashboard SourceCard theme safety
+
+**Files:**
+- `frontend/src/pages/dashboard/dashboard-page.tsx` (`SourceCard` + related slate-on-white)
+
+- [ ] Make SourceCard readable in light mode: either force dark surface (`bg-slate-900` both themes) OR map slate text to gray/slate with proper light/dark pairs
+- [ ] Prefer forcing dark card chrome for SourceCard (matches topology aesthetic) — set explicit `bg-slate-900 border-slate-700 text-slate-*` without relying on white Card default
+- [ ] Update dashboard tests if they assert classes
+- [ ] Commit: `fix(ui): fix dashboard source card light contrast`
+
+---
+
+## Task 4: CardTitle override cleanup (consistent cards)
+
+**Files:** all CardTitle call sites under `frontend/src/`
+
+- [ ] After Task 1 default change, remove redundant `text-sm font-medium` / `text-base font-medium` overrides that only duplicated sizing
+- [ ] Fix outliers that relied on old `text-lg` default without override (SSH Keys, Alert Thresholds) — they should now match `text-sm` automatically; keep icon+flex classes
+- [ ] Speedtest: drop `text-base` override so it matches board
+- [ ] Login may keep `text-2xl` on CardTitle
+- [ ] Grep remaining `CardTitle className=` and ensure no sizing drift except documented exceptions
+- [ ] Commit: `refactor(ui): unify CardTitle sizing across pages`
+
+---
+
+## Task 5: Loading → Skeleton
+
+**Files:** cards using `animate-pulse` placeholders or `"Loading…"` text (e.g. split-tunnel, mac-policy, wifi-schedule, ssh-keys-card)
+
+- [ ] Replace pulse placeholders with `Skeleton`
+- [ ] Replace ssh-keys `"Loading…"` with `Skeleton`
+- [ ] Leave `Loader2` on buttons/dialogs
+- [ ] Commit: `refactor(ui): standardize loading with Skeleton`
+
+---
+
+## Task 6: EmptyState adoption
+
+**Files:** clients empty table, logs empty, ssh keys empty, setup scan empty, any other one-off empties
+
+- [ ] Replace one-off empty copy with `<EmptyState message="…" />`
+- [ ] Keep icon optional
+- [ ] Update tests that look for old empty markup
+- [ ] Commit: `refactor(ui): use EmptyState for empty content`
+
+---
+
+## Task 7: Error UX → InlineError
+
+**Files:** speedtest, diagnostics, network speed-test, login root error, SQM failed load, etc.
+
+- [ ] Replace ad-hoc red error boxes / bare error paragraphs for **load/display** errors with `InlineError`
+- [ ] Do not change toast-based mutation feedback
+- [ ] Avoid `return null` on speedtest when status missing after load — show InlineError or EmptyState as appropriate
+- [ ] Commit: `refactor(ui): standardize inline errors`
+
+---
+
+## Task 8: Form Label migration
+
+**Files:** dense forms across network/wifi/vpn/system using `text-xs text-gray-500` labels
+
+- [ ] Migrate form field labels to `Label` component (or identical classes)
+- [ ] Ensure `dark:text-gray-400` present
+- [ ] Login: use Label with `className="text-sm font-medium text-gray-700 dark:text-gray-300"` if needed
+- [ ] Commit: `refactor(ui): migrate form labels to Label primitive`
+
+---
+
+## Task 9: Status chrome + shell titles
+
+**Files:**
+- Dashboard SourceCard status chip — theme-safe (Task 3 may cover)
+- `logs-level-badge.tsx` — align with `Badge` if straightforward
+- `frontend/src/router.tsx` (or title map) — consistent shell titles for sub-routes (`WiFi` stays flat OK; Services subpages keep `Services / X` OR document; prefer breadcrumb style for service children only)
+- Align custom success/fail dots to use consistent emerald/red pairing with dark variants where missing
+
+- [ ] Prefer Badge for log levels if visual parity OK; else leave LogsLevelBadge but ensure dark pairs
+- [ ] Normalize any remaining status pills that break light mode
+- [ ] Commit: `refactor(ui): align status chrome and shell titles`
+
+---
+
+## Task 10: Verify + docs index
+
+- [ ] Update `docs/plans/README.md` index row for this plan
+- [ ] Run `make lint`, `make test`, `make build` from worktree
+- [ ] Fix failures
+- [ ] Final commit if docs/fixes needed: `chore(ui): finish consistency verify`
+
+---
+
+## Done when
+
+- No protected page adds its own outer `p-4`/`p-6`
+- Card titles visually match across Settings-like cards
+- SourceCards readable in light + dark
+- No card content `Loading…` / pulse placeholders remain (except button spinners)
+- Empty/load-error paths use EmptyState / InlineError
+- Labels use shared Label (or identical classes) with dark variants
+- Lint, tests, build green

--- a/docs/plans/2026-07-20-ui-consistency.md
+++ b/docs/plans/2026-07-20-ui-consistency.md
@@ -134,10 +134,10 @@ tags: [frontend, ux, theming, consistency]
 
 **Files:** clients empty table, logs empty, ssh keys empty, setup scan empty, any other one-off empties
 
-- [ ] Replace one-off empty copy with `<EmptyState message="…" />`
-- [ ] Keep icon optional
-- [ ] Update tests that look for old empty markup
-- [ ] Commit: `refactor(ui): use EmptyState for empty content`
+- [x] Replace one-off empty copy with `<EmptyState message="…" />`
+- [x] Keep icon optional
+- [x] Update tests that look for old empty markup
+- [x] Commit: `refactor(ui): use EmptyState for empty content`
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,7 +1,7 @@
 ---
 title: Plans index
 description: Searchable catalog of all planning and historical design docs in this directory.
-updated: 2026-04-13
+updated: 2026-07-21
 tags: [plans, traceability, index]
 ---
 
@@ -22,6 +22,8 @@ YAML **frontmatter** on each plan file carries `title`, `description`, `updated`
 | [`2026-07-08-hardening-followups-and-persistence.md`](2026-07-08-hardening-followups-and-persistence.md) | Work log + queue: vpn sleeps, wifi split, WS-fed queries, bbolt persistence | `reliability`, `persistence`, `refactor` |
 | [`2026-07-20-ui-consistency.md`](2026-07-20-ui-consistency.md) | Unify page shell, cards, loading/empty/error, labels, status chrome | `frontend`, `ux`, `theming`, `consistency` |
 | [`2026-07-20-nested-cards-approach-a.md`](2026-07-20-nested-cards-approach-a.md) | Flatten nested panels, equal-height WiFi cards, form chrome (shadcn-like) | `frontend`, `ux`, `cards` |
+| [`_primitive-usage-audit.md`](_primitive-usage-audit.md) | Call-site audit: Select h-9, form `sm` buttons, CardInset leftovers, Badge bypass | `frontend`, `ux`, `audit` |
+| [`_primitive-mop-report.md`](_primitive-mop-report.md) | Mop-up: Select h-10, form buttons, CardInset, Badge variants, docs | `frontend`, `ux` |
 | [`adguard-auto-configure.md`](adguard-auto-configure.md) | AdGuard install + dnsmasq integration | `adguard`, `dns`, `services` |
 | [`cicd-pipeline.md`](cicd-pipeline.md) | CI/CD for build/test/package | `cicd`, `deployment` |
 | [`connection-failover.md`](connection-failover.md) | Multi-WAN failover | `wan`, `failover`, `network` |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -20,6 +20,7 @@ YAML **frontmatter** on each plan file carries `title`, `description`, `updated`
 | [`2026-04-11-repeater-radio-policy-and-wifi-ux.md`](2026-04-11-repeater-radio-policy-and-wifi-ux.md) | Repeater radio policy, unified AP UX | `wifi`, `repeater` |
 | [`2026-07-08-auth-hardening.md`](2026-07-08-auth-hardening.md) | Auth follow-ups: blocklist persistence, WS token transport, token storage | `auth`, `security` |
 | [`2026-07-08-hardening-followups-and-persistence.md`](2026-07-08-hardening-followups-and-persistence.md) | Work log + queue: vpn sleeps, wifi split, WS-fed queries, bbolt persistence | `reliability`, `persistence`, `refactor` |
+| [`2026-07-20-ui-consistency.md`](2026-07-20-ui-consistency.md) | Unify page shell, cards, loading/empty/error, labels, status chrome | `frontend`, `ux`, `theming`, `consistency` |
 | [`adguard-auto-configure.md`](adguard-auto-configure.md) | AdGuard install + dnsmasq integration | `adguard`, `dns`, `services` |
 | [`cicd-pipeline.md`](cicd-pipeline.md) | CI/CD for build/test/package | `cicd`, `deployment` |
 | [`connection-failover.md`](connection-failover.md) | Multi-WAN failover | `wan`, `failover`, `network` |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -21,6 +21,7 @@ YAML **frontmatter** on each plan file carries `title`, `description`, `updated`
 | [`2026-07-08-auth-hardening.md`](2026-07-08-auth-hardening.md) | Auth follow-ups: blocklist persistence, WS token transport, token storage | `auth`, `security` |
 | [`2026-07-08-hardening-followups-and-persistence.md`](2026-07-08-hardening-followups-and-persistence.md) | Work log + queue: vpn sleeps, wifi split, WS-fed queries, bbolt persistence | `reliability`, `persistence`, `refactor` |
 | [`2026-07-20-ui-consistency.md`](2026-07-20-ui-consistency.md) | Unify page shell, cards, loading/empty/error, labels, status chrome | `frontend`, `ux`, `theming`, `consistency` |
+| [`2026-07-20-nested-cards-approach-a.md`](2026-07-20-nested-cards-approach-a.md) | Flatten nested panels, equal-height WiFi cards, form chrome (shadcn-like) | `frontend`, `ux`, `cards` |
 | [`adguard-auto-configure.md`](adguard-auto-configure.md) | AdGuard install + dnsmasq integration | `adguard`, `dns`, `services` |
 | [`cicd-pipeline.md`](cicd-pipeline.md) | CI/CD for build/test/package | `cicd`, `deployment` |
 | [`connection-failover.md`](connection-failover.md) | Multi-WAN failover | `wan`, `failover`, `network` |

--- a/docs/plans/_approach-a-report.md
+++ b/docs/plans/_approach-a-report.md
@@ -1,0 +1,52 @@
+# Approach A report — nested cards / form chrome
+
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `.worktrees/ui-consistency`  
+**Commit message:** `fix(ui): flatten nested cards and align form chrome`  
+**Status:** done
+
+## Summary
+
+- Added shared `CardInset` (`default` / `muted`) for nested regions without a second card shadow.
+- Equal-height WiFi Current Connection / Saved Networks sibling cards.
+- Shortened Scan / Hidden button labels; wrap button rows; full names in `aria-label` / `title`.
+- Flattened nested bordered panels to `CardInset` across WiFi AP / guest / MAC / schedule.
+- DNS + DHCP Add buttons default `h-10`; Diagnostics tablist matches page tab-bar; Run `h-10`.
+- Services `ServiceCard`: `shadow-none` so outer Installed Services card keeps elevation.
+
+## Files changed
+
+### New
+- `frontend/src/components/ui/card-inset.tsx`
+- `docs/plans/_approach-a-report.md` (this file)
+
+### Docs
+- `docs/ui-theming.md` — Nested regions → CardInset
+
+### WiFi equal-height + Scan/Hidden
+- `frontend/src/pages/wifi/wifi-wireless-panel.tsx`
+- `frontend/src/pages/wifi/wifi-current-connection-card.tsx`
+- `frontend/src/pages/wifi/wifi-saved-networks-card.tsx`
+- `frontend/src/pages/wifi/wifi-scan-dialog.tsx`
+- `frontend/src/pages/wifi/wifi-hidden-network-dialog.tsx`
+- `frontend/src/pages/wifi/__tests__/wifi-page.test.tsx`
+
+### Nested panels → CardInset
+- `frontend/src/pages/wifi/ap-config-card.tsx`
+- `frontend/src/pages/wifi/ap-radio-section.tsx`
+- `frontend/src/pages/wifi/ap-unified-config-form.tsx`
+- `frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx`
+- `frontend/src/pages/wifi/mac-policy-add-form.tsx`
+- `frontend/src/pages/wifi/wifi-schedule-form-fields.tsx`
+
+### DNS / Diagnostics / Services
+- `frontend/src/pages/network/dns-entries-card.tsx`
+- `frontend/src/pages/network/dhcp-reservation-add-form.tsx`
+- `frontend/src/pages/network/diagnostics-card.tsx`
+- `frontend/src/pages/services/service-card.tsx`
+
+## Tests
+
+`cd frontend && pnpm test` (via root `make test` path): **48 files / 262 tests passed**.
+
+Also: shared 58 passed; backend go tests ok.

--- a/docs/plans/_primitive-mop-report.md
+++ b/docs/plans/_primitive-mop-report.md
@@ -1,0 +1,38 @@
+---
+title: Primitive usage mop-up report
+description: Select h-10, form button height, CardInset leftovers, Badge variants, docs.
+updated: 2026-07-21
+tags: [frontend, ux, mop-up]
+worktree: /Users/marbaced/projects/raydak/travo/.worktrees/ui-consistency
+branch: fix/ui-consistency
+status: done
+---
+
+# Primitive usage mop-up report
+
+Executed against audit [`_primitive-usage-audit.md`](_primitive-usage-audit.md) Top 10 + HIGH/MEDIUM tables.
+
+## Done
+
+| Item | Change |
+|------|--------|
+| **SelectTrigger** | Default `h-9` → `h-10`; dark border `gray-700` → `white/10` |
+| **Form buttons** | Dropped `size="sm"` (and `h-7`/`h-8` mismatches) on labeled Input rows: WoL, MAC policy, port-forward, Tailscale auth, reserve-IP, AdGuard password Save/Cancel, MAC clone, NTP (trash → `size="icon"`), WG import submit, failover edit Save/Cancel, data-usage budget, LED schedule Save |
+| **CardInset** | DNS tools, radio hardware rows, WG kill switch + peers, failover candidates, data-usage iface, LED schedule, repeater configure-AP panels (kept blue info banner) |
+| **Badge variants** | VPN verify, USB tethering, Tailscale panel/peer, radio Recommended |
+| **CardHeader icons** | Dashboard Quick status → trailing sibling |
+| **ServiceCard** | `CardHeader` + `CardTitle`; keep `shadow-none` |
+| **Docs** | `ui-theming.md` form density / Select h-10 / CardInset / Badge exceptions; plans README index |
+
+## Verify
+
+- `cd frontend && pnpm test` → **48 files, 262 tests passed**
+
+## Leftovers (intentional / out of scope)
+
+- Dense `size="sm"` toolbars (logs, header, service actions, failover Move up/down, USB WAN actions, AdGuard “Change”)
+- `SourceCard` custom status pill + icon-in-title (documented exception)
+- `LogsLevelBadge` parallel system (documented)
+- System Header-less Cards (power / quick links)
+- Optional: Switch label density; Label vs `Input label=` dual API; field-level `text-red-500` vs InlineError
+- Other hand-rolled borders outside audit list

--- a/docs/plans/_primitive-usage-audit.md
+++ b/docs/plans/_primitive-usage-audit.md
@@ -1,0 +1,162 @@
+---
+title: Primitive usage consistency audit
+description: Independent audit of Card / Button / Badge (+ Label, Select, Switch) call-site consistency vs ui-theming + shadcn patterns.
+updated: 2026-07-21
+tags: [frontend, ux, audit, primitives]
+worktree: /Users/marbaced/projects/raydak/travo/.worktrees/ui-consistency
+branch: fix/ui-consistency
+status: findings-only (no fixes)
+---
+
+# Primitive usage consistency audit
+
+Audit of Travо frontend usage of shared UI primitives against:
+
+- `docs/ui-theming.md`
+- `docs/plans/_shadcn-ui-patterns.md`
+- `docs/plans/2026-07-20-ui-consistency.md`
+- `docs/plans/2026-07-20-nested-cards-approach-a.md`
+- primitives under `frontend/src/components/ui/{card,button,badge,card-inset,input,label,empty-state,inline-error}.tsx`
+
+Method: ripgrep counts + read of wifi / network / vpn / system / services / dashboard / clients / logs pages. Cross-checked prior nested-cards audit (`_ui-nested-cards-audit.md`) for delta after Approach A.
+
+---
+
+## 1. Verdict
+
+**MOSTLY_CONSISTENT**
+
+Primitives exist, theme contracts documented, and most pages compose `Card` → `CardHeader` → `CardTitle` → `CardContent`. Feedback (`EmptyState`, `InlineError`, `Skeleton`) and `Label` are adopted on many dense forms. Remaining pain is **control-height mismatch** (`Button size="sm"` / `SelectTrigger h-9` vs `Input h-10`), **incomplete `CardInset` migration**, and **Badge variant bypass** via hand-rolled color classes.
+
+---
+
+## 2. Scores (1–10)
+
+| Area | Score | Notes |
+|------|------:|-------|
+| **Card** | **7** | Structure strong; WiFi core uses `CardInset`; VPN/network/wizard still raw borders; dual icon placement; few Header-less cards |
+| **Button** | **6** | Destructive + outline mostly disciplined; ~134 `size="sm"`; many next to default `Input` |
+| **Badge** | **7** | Variants used widely; several call sites re-paint success/destructive with `className`; one intentional parallel system (logs) |
+| **Overall** | **6** | Design system present; call-site height + inset + badge color debt keeps score mid |
+
+---
+
+## 3. Issues table
+
+| Sev | Primitive | Evidence | Fix suggestion |
+|-----|-----------|----------|----------------|
+| **HIGH** | Button | `wol-card.tsx:58` — `size="sm"` submit beside default `Input` (`h-10`) in labeled grid | Drop `size="sm"` (or set whole row to `sm` + shorter inputs); keep `items-end` |
+| **HIGH** | Button | `mac-policy-add-form.tsx:64` — Add `size="sm"` next to `Input`s inside `CardInset` | Default button height |
+| **HIGH** | Button | `firewall-port-forward-add-form-grid.tsx:104` — submit `size="sm"` + `self-end` with `Input`s | Default `h-10` |
+| **HIGH** | Button | `tailscale-auth-section.tsx:33` — submit `sm` + `Input` | Default height |
+| **HIGH** | Button | `reserve-ip-form.tsx:74` — submit `sm` + `Input`s | Default height |
+| **HIGH** | Button | `adguard-password-card.tsx:94` — Save `sm` next to password `Input`s | Default height for form actions |
+| **HIGH** | Button | `mac-address-clone-block.tsx:82–96` — Random / Apply / Cancel all `sm` beside `Input` | Default height (toolbar may stay `sm` if Input also compact) |
+| **HIGH** | Button | `ntp-config-server-fields.tsx:41,77` — icon/`sm` actions next to server `Input`s | Match input height or use `size="icon"` only for trash |
+| **HIGH** | Select | `select.tsx:20` — `SelectTrigger` default **`h-9`**; **0** call sites override `h-10` (14 triggers: SQM, DHCP, DDNS, guest, AP enc, timezone, hardware buttons, radio role, etc.) | Change primitive default to `h-10` (or add `h-10` at every form row) |
+| **HIGH** | Card / CardInset | WiFi migrated (`ap-*`, guest, schedule, mac-policy-add, saved-networks) = **7** `<CardInset` sites; leftovers still raw: `dns-tools-card.tsx:73`, `wifi-radio-hardware-card.tsx:71`, `wireguard-profiles-kill-import.tsx:82`, `wireguard-config-peers-list.tsx:21`, `failover-card.tsx:189`, `data-usage-interface-card.tsx:18`, `led-schedule-form.tsx:33`, repeater wizard `configure-ap-step.tsx` (many `rounded-lg border p-3/4`) | Replace same-family insets with `CardInset` / `variant="muted"`; keep semantic alert boxes separate |
+| **MEDIUM** | Badge | Custom colors duplicating variants: `vpn-verify-wireguard-card.tsx:74,78`, `usb-tethering-section.tsx:42,56`, `tailscale-logged-in-panel.tsx:46`, `tailscale-peer-row.tsx:25`, `wifi-radio-hardware-card.tsx:81` | Use `variant="success" \| "destructive" \| "default"`; drop color `className` |
+| **MEDIUM** | Badge | Dashboard `SourceCard` status chip is custom pill, not `Badge` — `dashboard-page.tsx:249–258` | Keep intentional (plan Task 9) **or** theme-safe `Badge` on forced-dark card |
+| **MEDIUM** | Card | `service-card.tsx:41–49` — nested flat `Card` without `CardHeader`/`CardTitle`; raw `<h3>` | Prefer `CardHeader`+`CardTitle` or non-Card list row if parent already cards |
+| **MEDIUM** | Card | `system-power-section.tsx:21–22`, `system-quick-links-card.tsx:47–48` — `Card` + `CardContent` only; section title is external `<h2>` | OK pattern for sectioned system page; document as exception **or** add `CardHeader` |
+| **MEDIUM** | Card | Header icon placement split: ~55 cards put Lucide **right** of title (`flex flex-row … justify-between`); dashboard Quick status puts icon **inside** `CardTitle` (`dashboard-page.tsx:382–384`); SourceCard wraps title+status in inner flex (`:236–246`) | Pick one: icon-in-title **or** trailing decorative icon; apply everywhere |
+| **MEDIUM** | Button | `data-usage-budget-editor.tsx:78` — `size="sm" className="h-7"` beside inputs (extra short) | Align to shared dense row height or default |
+| **MEDIUM** | Button | `wireguard-import-profile-form.tsx:52,88` — `sm` next to name `Input` / submit | Default submit height |
+| **MEDIUM** | Button | `failover-card.tsx:327+` — edit-mode Save/Cancel `sm` with `Input`s in candidate blocks | Default height in edit forms |
+| **MEDIUM** | CardInset border | VPN insets use `dark:border-gray-700` (`wireguard-profiles-kill-import.tsx:82`, `wireguard-config-peers-list.tsx:21`) vs theming rule `dark:border-white/10` on card-plane panels | Prefer `CardInset` (already `dark:border-white/10`) |
+| **MEDIUM** | Label / Input | Dual label APIs: ~29 files import `Label`; many forms use `<Label>` + bare `<Input>`; others use `Input label=` (e.g. alert thresholds, login). Both OK via `Input`→`Label`, but visual rhythm differs when `label=` wraps vs external `space-y-1` | Prefer one form-row pattern per page family (`Label` + `Input` in `space-y-1`) |
+| **MEDIUM** | Feedback | Field errors often bare `text-xs text-red-500` (`dns-entries-card.tsx:97`, `diagnostics-card.tsx:92`) while load errors use `InlineError` — contract says InlineError for load/display, not field validation | Keep field errors as-is; document exception |
+| **LOW** | Button | Dense toolbars correctly use `sm` (logs filters, header, service action rows, quick actions) — not a bug | No change; treat as intentional density |
+| **LOW** | Badge | `LogsLevelBadge` (`logs-level-badge.tsx:4–14`) parallel to `Badge` | Keep; comment already documents why |
+| **LOW** | Switch | `Switch` built-in label is `text-sm text-gray-700 dark:text-gray-300` (`switch.tsx:16`) vs form `Label` `text-xs … gray-500` — denser forms look uneven next to switches | Optional: denser switch label variant |
+| **LOW** | Switch / a11y | `split-tunnel-card.tsx:71,80` — bare `<label>` + checkbox instead of `Switch` | Migrate to `Switch` if product wants toggle chrome |
+| **LOW** | Theming | `service-card.tsx:55,78` — `text-gray-400` without dark pair on version / hint | Add `dark:text-gray-500` (or inherit) |
+| **LOW** | Card | Login `CardTitle` `text-2xl` (`login-page-card-header.tsx:11`) | Documented exception — keep |
+| **LOW** | Empty / loading | EmptyState / Skeleton widely used; residual `"Loading…"` mainly in-button (e.g. quick links AdGuard Config) | OK per contract |
+
+### Severity counts
+
+| Severity | Count |
+|----------|------:|
+| HIGH | 10 |
+| MEDIUM | 11 |
+| LOW | 8 |
+
+---
+
+## 4. What's solid
+
+- **Card chrome**: shared `Card` border/`dark:border-white/10` / shadow; ~69 import sites; almost all settings cards use Header + Title + Content.
+- **CardTitle default**: `text-sm font-medium` matches contract; sizing overrides nearly gone (login `text-2xl` only intentional hero).
+- **WiFi Approach A**: equal-height grid (`wifi-wireless-panel.tsx:28–34` + `h-full flex flex-col` on saved/current); `CardInset` on AP / guest / schedule / MAC add / auto-reconnect; scan row `flex-wrap` (`wifi-current-connection-card.tsx:51`).
+- **DNS Add row**: `dns-entries-card.tsx:83–119` — `items-end` + **default** `Button` (fixed vs older `sm` audit).
+- **Diagnostics Run**: default `Button` beside `Input` (`diagnostics-card.tsx:77–89`).
+- **Badge variants**: success/secondary/outline/destructive used correctly on WAN, interfaces, firewall policy, services state map, VPN leak test.
+- **Label**: dedicated primitive; Input wires `label=` through `Label`; dense network/wifi/vpn forms largely migrated.
+- **EmptyState / InlineError / Skeleton**: feedback contract largely landed (EmptyState ~25 files; InlineError on diagnostics, speedtest paths, etc.).
+- **Destructive buttons**: reboot/shutdown/factory, confirm dialogs, service remove — consistent `variant="destructive"`.
+- **Service nested Card**: `shadow-none hover:shadow-none` (`service-card.tsx:41`) — Approach A Services flatten done.
+
+---
+
+## 5. Top 10 fix targets (ranked)
+
+1. **Bump `SelectTrigger` default to `h-10`** (`select.tsx`) — one change fixes all 14 form selects.
+2. **Form submit rows: remove `size="sm"` next to default `Input`** — WoL, MAC policy add, port-forward, Tailscale auth, reserve-IP, AdGuard password, MAC clone, NTP servers, WireGuard import, failover edit.
+3. **Finish `CardInset` migration** for VPN peer/import panels, DNS tools inset, radio hardware rows, failover candidates, data-usage iface cards, LED schedule form.
+4. **Badge: replace hand-rolled green/red/blue `className` with variants** (VPN verify, USB tethering, Tailscale panels, radio hardware).
+5. **Normalize CardHeader decorative icons** (trailing sibling vs in-title) across ~55 flex-row headers + dashboard.
+6. **VPN / wizard dark borders** → `dark:border-white/10` or `CardInset` (drop `dark:border-gray-700` on card-plane insets).
+7. **ServiceCard title structure** — use `CardTitle` or drop Card wrapper in favor of list item chrome.
+8. **Document form density tiers** — when `sm` is allowed (toolbars, icon rows) vs forbidden (labeled Input grids).
+9. **Switch label density** optional align to `Label` on settings cards.
+10. **SourceCard chip** — either keep + document, or map to outline/success Badge on slate surface.
+
+---
+
+## 6. Intentional exceptions
+
+| Exception | Where | Why |
+|-----------|--------|-----|
+| Login hero `CardTitle text-2xl` | `login-page-card-header.tsx` | Plan + theming contract |
+| Setup outside AppShell / step titles | `setup-page.tsx` | Plan |
+| Dashboard `SourceCard` forced dark + custom status pill | `dashboard-page.tsx:234–258` | Plan Task 3 / Task 9; topology aesthetic |
+| `LogsLevelBadge` ≠ `Badge` | `logs-level-badge.tsx` | Dense uppercase terminal chips; comment documents |
+| `ServiceCard` flat nested Card | `service-card.tsx` | Parent Installed Services Card; `shadow-none` by design |
+| System section `<h2>` + Header-less Card | power / quick links | Section rhythm, not card chrome |
+| Header / logs / service action `size="sm"` | many | Dense chrome, not form-row with Input |
+| Hostname inline `h-6` Input+Button | `hostname-inline-form.tsx:55–75` | Inline edit in glance row |
+| Semantic alert boxes (amber/red/blue) | health banners, wizards, timezone alert | Not `CardInset`; status surfaces |
+| Field-level `text-red-500` errors | forms | Not load/display `InlineError` |
+| Tab bars (WiFi/Network/Diagnostics) | shared segmented control | Not Card nesting |
+
+---
+
+## Counts snapshot (worktree)
+
+| Signal | Approx |
+|--------|--------|
+| Files importing `card` | 69 |
+| Files importing `badge` | 34 |
+| Files importing `label` | 29 |
+| `<CardInset` call sites | 7 |
+| `size="sm"` occurrences | 134 |
+| `SelectTrigger` call sites | 14 (all default `h-9`) |
+| Badge `variant="success"` | 7 |
+| Badge custom `bg-green` overrides | 4+ files |
+| EmptyState consumers | ~25 |
+| InlineError consumers | ~9 |
+
+---
+
+## Delta vs `_ui-nested-cards-audit.md`
+
+Already improved since that audit:
+
+- Current/Saved equal-height + `CardInset` auto-reconnect
+- AP / guest / schedule / MAC add → `CardInset`
+- DNS Add button height fixed
+- Diagnostics tab chrome + Run `h-10`
+- Services nested shadow stripped
+
+Still open from that audit + this pass: Select `h-9`, widespread form `sm` buttons, non-WiFi inset leftovers, Badge color bypasses, header icon placement.

--- a/docs/plans/_task-10-mop-report.md
+++ b/docs/plans/_task-10-mop-report.md
@@ -1,0 +1,43 @@
+# Task 10 mop — residual UI consistency
+
+**Status:** done  
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `.worktrees/ui-consistency`  
+**Commit message:** `fix(ui): mop residual consistency gaps from audit`
+
+## Fixed (MEDIUM)
+
+| ID | Fix |
+|----|-----|
+| M1 | SourceCard empties unified to slate `<p className="text-slate-500">` (Ethernet matched Repeater/USB; dropped light EmptyState on forced-dark chrome) |
+| M2 | Replaced undefined shadcn tokens (`text-muted-foreground`, `border-border`, `bg-muted/*`, `text-foreground`, `border-input`, `bg-background`, `ring-ring`, `text-destructive`) with theme-safe gray/border/input pairs |
+| M3 | `DataUsageSection` loading → Card + Skeleton (no more `return null`) |
+| M4 | Swept `text-gray-500` → add `dark:text-gray-400` across `frontend/src` secondary/hint/icon chrome |
+| M5 | ipv6 / led-stealth Label-like headers got dark pairs in sweep |
+| M6 | Data Usage “not installed” → `EmptyState` |
+
+## Fixed (LOW, quick)
+
+| ID | Fix |
+|----|-----|
+| L1 | Setup `CardTitle` → `text-gray-500 dark:text-gray-400` |
+
+Left alone: L2 radio wrappers, L3 captive status rows, L4/L5 semantic red.
+
+## Docs
+
+- Indexed `2026-07-20-ui-consistency.md` in `docs/plans/README.md`
+
+## Tests
+
+```text
+cd frontend && pnpm test
+Test Files  48 passed (48)
+Tests       262 passed (262)
+```
+
+## Out of scope / untouched
+
+- `frontend/public/mockServiceWorker.js`
+- Status color semantics (emerald/red)
+- SourceCard forced-dark slate body text (kept `text-slate-*`)

--- a/docs/plans/_task-4-report.md
+++ b/docs/plans/_task-4-report.md
@@ -1,0 +1,45 @@
+# Task 4 Report — CardTitle override cleanup
+
+**Status:** done
+**Commit:** `refactor(ui): unify CardTitle sizing across pages`  
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `.worktrees/ui-consistency`
+
+## Changes
+
+- Removed redundant `text-sm font-medium` / `text-base font-medium` from CardTitle call sites (default already `text-sm font-medium`)
+- **71** call sites cleaned across **61** files
+- Kept layout classes: `flex items-center gap-2`, `text-center`, etc.
+- Kept Login exception: `text-2xl`
+- Kept Setup non-size theme classes: `text-center text-gray-500`
+- Speedtest: dropped `text-base font-medium` → bare `<CardTitle>`
+- SSH Keys / Alert Thresholds: unchanged (`flex items-center gap-2` only; inherit default size)
+- Dashboard SourceCard: kept `flex … text-slate-100`; Quick status: kept `flex …` only
+- Did not touch loading/empty/error/labels or `mockServiceWorker.js`
+
+## Remaining CardTitle className (post-cleanup)
+
+| Site | className | Notes |
+|------|-----------|--------|
+| Login | `text-2xl` | documented exception |
+| Setup | `text-center text-gray-500` | non-size theme/layout |
+| Dashboard SourceCard | `flex items-center gap-2 text-slate-100` | layout + forced-dark title |
+| Dashboard Quick status | `flex items-center gap-2` | layout |
+| SSH Keys | `flex items-center gap-2` | layout |
+| Alert Thresholds | `flex items-center gap-2` | layout |
+| card.test.tsx | `flex items-center gap-2` | layout merge test |
+
+No remaining `text-sm` / `text-base` / `font-medium` sizing drift on CardTitle call sites.
+
+## Test summary
+
+```
+cd frontend && pnpm test
+→ Test Files  48 passed (48)
+→ Tests       260 passed (260)
+```
+
+## Concerns
+
+- Setup CardTitle still light-only `text-gray-500` (no `dark:` pair) — pre-existing; out of Task 4 scope (kept as instructed).
+- SourceCard title still overrides color via `text-slate-100` (needed for forced-dark chrome from Task 3).

--- a/docs/plans/_task-5-report.md
+++ b/docs/plans/_task-5-report.md
@@ -1,0 +1,42 @@
+# Task 5 Report — Loading → Skeleton
+
+**Status:** done  
+**Commit hash:** `ce527f86f688e912f39d7d4438e6b5fd860d07f1`  
+**Commit:** `refactor(ui): standardize loading with Skeleton`  
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `.worktrees/ui-consistency`
+
+## Changes
+
+- Replaced `animate-pulse` placeholder `<div>`s with `<Skeleton className="h-16 w-full" />` in:
+  - `frontend/src/pages/wifi/wifi-schedule-card.tsx`
+  - `frontend/src/pages/wifi/mac-policy-card.tsx`
+  - `frontend/src/pages/vpn/split-tunnel-card.tsx`
+- Replaced ssh-keys `"Loading…"` text with `<Skeleton className="h-16 w-full" />` in `frontend/src/pages/system/ssh-keys-card.tsx` (loading only; empty-state left for Task 6)
+- Left existing `Skeleton` call sites untouched
+- Left `Loader2` / button busy states untouched
+- Left `system-quick-links-card` button label `Loading…` (fetch busy on AdGuard link, not card content placeholder)
+- Did not touch EmptyState / InlineError / `mockServiceWorker.js`
+
+## Post-grep
+
+| Pattern | Remaining |
+|---------|-----------|
+| `animate-pulse` outside Skeleton | none (only `skeleton.tsx` + speedtest test asserting Skeleton’s class) |
+| Card content `"Loading…"` | none |
+| Button busy `"Loading…"` | `system-quick-links-card` AdGuard fetch label (intentional) |
+
+## Test summary
+
+```
+cd frontend && pnpm test
+→ Test Files  48 passed (48)
+→ Tests       260 passed (260)
+```
+
+No test updates required (no assertions on old pulse markup / `"Loading…"` for these cards).
+
+## Concerns
+
+- `system-quick-links-card` still shows text `Loading…` on button while AdGuard config fetches — out of Task 5 card-content scope; could later use `Loader2` for consistency with other busy buttons.
+- Skeleton height `h-16` matches prior pulse blocks; denser multi-line skeletons elsewhere already use stacked `h-4`/`h-10` patterns — fine to leave as-is.

--- a/docs/plans/_task-6-report.md
+++ b/docs/plans/_task-6-report.md
@@ -1,0 +1,43 @@
+# Task 6 Report — EmptyState adoption
+
+**Status:** done
+**Commit hash:**     
+**Commit:** `refactor(ui): use EmptyState for empty content`  
+**Branch:** `fix/ui-consistency`
+
+## Files changed
+
+- `frontend/src/pages/clients/clients-connected-table.tsx`
+- `frontend/src/components/clients/clients-dhcp-reservations-card.tsx`
+- `frontend/src/pages/logs/logs-text-view.tsx`
+- `frontend/src/pages/system/ssh-keys-list.tsx`
+- `frontend/src/pages/setup/setup-wifi-network-list.tsx`
+- `frontend/src/pages/wifi/wifi-scan-list.tsx`
+- `frontend/src/pages/wifi/mac-policy-table.tsx`
+- `frontend/src/pages/wifi/mac-address-card.tsx`
+- `frontend/src/pages/network/wan-config-card.tsx`
+- `frontend/src/pages/network/ipv6-card.tsx`
+- `frontend/src/pages/dashboard/dashboard-page.tsx`
+- `frontend/src/components/layout/header-notifications-menu.tsx`
+- `docs/plans/2026-07-20-ui-consistency.md` (Task 6 checkboxes)
+- `docs/plans/_task-6-report.md`
+
+## What changed
+
+- Replaced one-off empty `<p>` / `<span>` / div copy with `<EmptyState message="…" />`.
+- Logs empty path: render `EmptyState` instead of gray text inside the terminal `<pre>` (pre only when lines exist).
+- Left loading (`Skeleton`) and `InlineError` untouched.
+- Did not migrate install/CTA prompts (Tailscale/WireGuard), chart “Waiting…/Collecting…” placeholders, or form labels.
+- Did not touch `mockServiceWorker.js`.
+
+## Tests
+
+- `cd frontend && pnpm test -- --run` (clients, logs, system, wifi, setup, network, dashboard, clients/layout components): **48 files / 262 tests passed**
+- No existing tests asserted old empty markup; copy strings preserved so assertions by text still match.
+
+## Concerns
+
+- Logs empty no longer mounts `data-testid="log-content"` (only when lines present). Mock data keeps current logs test green; empty-log tests would need EmptyState text query.
+- Dashboard SourceCard Ethernet empty now uses shared EmptyState (gray theme tokens) on forced-dark SourceCard — contrast OK, visual weight slightly different (`py-6` center).
+- Parallel Label migration edits were present in worktree; **not** included in this commit.
+- Concurrent agents reset branch during earlier commit attempts; this commit re-applied EmptyState-only paths.

--- a/docs/plans/_task-7-report.md
+++ b/docs/plans/_task-7-report.md
@@ -1,0 +1,44 @@
+# Task 7 Report — Error UX → InlineError
+
+**Status:** DONE  
+**Commit:** `1ac60d63cd164bd0dc4e103e40cfba9bd9d68809`  
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `/Users/marbaced/projects/raydak/travo/.worktrees/ui-consistency`
+
+## Changes
+
+- Migrated load/display error chrome to `InlineError` (children API; no `message` prop):
+  - `speedtest-page.tsx` — status load error + run mutation error; wrap error/`!status` in `space-y-6`
+  - `speedtest-page.tsx` — `!status` after load → `EmptyState` (no more `return null`)
+  - `diagnostics-card.tsx` — diagnostics run error
+  - `speed-test-card.tsx` — network speed test error
+  - `vpn-speed-test-card.tsx` — VPN speed test error
+  - `login-form-fields.tsx` — root auth error (kept AlertCircle via children + `flex` className)
+  - `sqm-section.tsx` — failed SQM config load
+- Updated `speedtest-page.test.tsx` (role=alert, empty state, run error)
+
+## Skipped (intentional)
+
+- Field-level validation `<p role="alert">` / `text-red-*` (not load/display boxes)
+- Sonner toasts
+- Status banners / confirm dialogs (`wifi-health-banner`, `confirm-radio-disable-dialog`, etc.)
+- Loading / EmptyState / Label migrations (other tasks)
+- `frontend/public/mockServiceWorker.js`
+
+## Tests
+
+```text
+pnpm exec vitest run \
+  src/pages/services/__tests__/speedtest-page.test.tsx \
+  src/pages/login/__tests__/login-page.test.tsx \
+  src/pages/services/__tests__/sqm-page.test.tsx \
+  src/components/ui/__tests__/inline-error.test.tsx \
+  src/pages/vpn/__tests__/vpn-page.test.tsx
+→ 5 files, 26 tests passed
+```
+
+## Concerns
+
+- Diagnostics / network / VPN speed-test error text now uses InlineError `text-sm` (was `text-xs` in a few cards) — slight size bump, intentional per primitive contract.
+- Login root error dark bg was `dark:bg-red-950/50` / `dark:text-red-400`; now shared InlineError `dark:bg-red-950` / `dark:text-red-300`. Login tests still assert `border-red` / `bg-red` only.
+- Full `make lint` / `make test` / `make build` deferred to Task 10 per plan cadence.

--- a/docs/plans/_task-8-report.md
+++ b/docs/plans/_task-8-report.md
@@ -1,0 +1,57 @@
+# Task 8 Report — Form Label migration
+
+**Status:** DONE  
+**Commit:** `refactor(ui): migrate form labels to Label primitive` (tip of `fix/ui-consistency`)  
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `/Users/marbaced/projects/raydak/travo/.worktrees/ui-consistency`
+
+## Changes
+
+Migrated dense form field `<label>` elements to shared `Label` (`text-xs font-medium text-gray-500 dark:text-gray-400`).
+
+**Files migrated: 29**
+
+| Area | Files |
+|------|-------|
+| Network | `dns-entries-card`, `wol-card`, `dhcp-reservation-add-form`, `firewall-port-forward-add-form-grid`, `lan-dns-server-fields`, `dhcp-pool-form-fields`, `ddns-enabled-fields`, `failover-card` |
+| System | `system-timezone-card`, `ntp-config-server-fields`, `ntp-config-edit-form`, `led-schedule-form`, `firmware-upgrade-form-fields` |
+| WiFi | `mac-address-clone-block`, `ap-unified-config-form`, `ap-radio-form-credentials-and-actions`, `guest-wifi-enabled-fields`, `wifi-schedule-form-fields`, `wifi-hidden-network-dialog-fields`, `confirm-radio-disable-dialog`, `repeater-wizard/configure-ap-step`, `repeater-wizard/select-upstream-step` |
+| VPN | `split-tunnel-card` (CIDR field only) |
+| Auth/Setup | `login-form-fields`, `ap-step-credentials-fields`, `password-step-form-fields`, `wifi-step-password-field` |
+| Services | `sqm-section` |
+| Primitives | `components/ui/input.tsx` (`label` prop → `Label`) |
+
+~68 `<Label>` call sites. Login/setup/confirm/SQM/failover keep prominence via `className` overrides (`text-sm …`). Dense wifi/network labels drop redundant `text-xs`/`text-gray-600` (contract `text-gray-500`).
+
+## Skipped (intentional)
+
+- Radio/checkbox wrappers with `cursor-pointer` (`split-tunnel` modes, `wifi-connect-dialog` band picker)
+- `switch.tsx` primitive wrapper
+- Helper `<p>` / section headings / table chrome (not field labels)
+- EmptyState parallel edits in other files (not staged)
+- `frontend/public/mockServiceWorker.js`
+
+## Tests
+
+`54e724e1969118c885285e694f827870d861fd36``text
+pnpm exec vitest run \
+  src/components/ui/__tests__/label.test.tsx \
+  src/pages/login/__tests__/login-page.test.tsx \
+  src/pages/setup/__tests__/ap-step.test.tsx \
+  src/pages/wifi/__tests__/wifi-connect-dialog.test.tsx \
+  src/components/wifi/__tests__/repeater-wizard.test.tsx \
+  src/pages/services/__tests__/sqm-page.test.tsx \
+  src/pages/vpn/__tests__/vpn-page.test.tsx \
+  src/pages/network/__tests__ \
+  src/pages/system/__tests__ \
+  src/pages/wifi/__tests__
+→ 12 files, 58 tests passed
+`54e724e1969118c885285e694f827870d861fd36``
+
+No test updates required (queries by accessible name still resolve).
+
+## Concerns
+
+- Dense labels that used `text-gray-600` now contract `text-gray-500` (intentional).
+- `Input` built-in `label` prop now renders `Label` with login-style `text-sm` override — wireguard/alert thresholds pick this up automatically.
+- Full `make lint` / `make test` / `make build` deferred to Task 10.

--- a/docs/plans/_task-9-report.md
+++ b/docs/plans/_task-9-report.md
@@ -1,7 +1,7 @@
 # Task 9 Report — Status chrome + shell titles
 
 **Status:** done  
-**Commit:** `refactor(ui): align status chrome and shell titles`  
+**Commit:** `4817a86` (`refactor(ui): align status chrome and shell titles`)  
 
 **Branch:** `fix/ui-consistency`  
 **Worktree:** `.worktrees/ui-consistency`

--- a/docs/plans/_task-9-report.md
+++ b/docs/plans/_task-9-report.md
@@ -1,0 +1,66 @@
+# Task 9 Report — Status chrome + shell titles
+
+**Status:** done  
+**Commit:** `refactor(ui): align status chrome and shell titles`  
+
+**Branch:** `fix/ui-consistency`  
+**Worktree:** `.worktrees/ui-consistency`
+
+## Changes
+
+### Quick status (dashboard)
+
+- Dropped forced `dark:border-slate-700 dark:bg-slate-900` on Quick status — normal theme Card (white / dark panel).
+- Internet: `text-emerald-600 dark:text-emerald-400` / `text-red-600 dark:text-red-400`.
+- VPN On: emerald light+dark pair; VPN Off: `text-gray-500 dark:text-gray-400` (no slate-on-white leftover).
+- Monitor icon: `text-gray-500 dark:text-gray-400`.
+
+### Logs level badge
+
+- Kept custom dense uppercase spans — `ui/Badge` is rounded-full pastel; not visual parity with terminal chips.
+- `LOG_LEVEL_COLORS` + fallback: dark pairs; `notice` uses emerald (was green).
+
+### Shell titles
+
+Convention (unchanged; documented in `router.tsx` comment + here):
+
+| Route area | Shell title |
+|------------|-------------|
+| Top-level pages | Flat (`Dashboard`, `Clients`, `VPN`, `Services`, `System`, `Logs`) |
+| WiFi sub-routes (`/wifi`, `/wifi/advanced`) | Flat `WiFi` (in-page tabs) |
+| Network sub-routes (`/network`, `/configuration`, `/advanced`) | Flat `Network` (in-page tabs) |
+| Service children | Breadcrumb `Services / Tailscale`, `Services / SQM`, `Services / Speedtest` |
+
+Header `h1` already single style: `text-lg font-semibold text-gray-900 dark:text-white`.
+
+### Success/fail status dots → emerald/red + dark
+
+- `header-router-status`, `network-chart`, `interface-traffic-charts`, `uptime-log-card`, `tailscale-peer-row`, `ddns-status-panel`, `wan-status-card`.
+- Offline/inactive dots: `bg-gray-300/400` + `dark:bg-gray-600`.
+- Glow shadows retinted to emerald `rgba(16,185,129,0.6)`.
+
+### Preserved
+
+- Network Status **Connected Clients** table untouched (`network-page-status-panel.tsx`).
+- Did not touch `mockServiceWorker.js`.
+- Did not rewrite gray helper text beyond status chrome / titles / Quick status leftovers.
+
+## Test summary
+
+```
+cd frontend && pnpm exec vitest run \
+  src/pages/dashboard/__tests__/dashboard-page.test.tsx \
+  src/pages/logs/__tests__/logs-page.test.tsx \
+  src/pages/network/__tests__/network-page.test.tsx \
+  src/components/layout/__tests__/sidebar.test.tsx
+→ Test Files  4 passed (4)
+→ Tests       22 passed (22)
+```
+
+Dashboard test asserts Quick status emerald/gray theme pairs for Reachable + VPN On/Off.
+
+## Concerns
+
+- `Badge` `success` variant still uses green (not emerald) — left alone; only custom dots aligned.
+- CheckCircle / Shield icons elsewhere may still use `text-green-500` without dark pairs — out of Task 9 dot scope.
+- SourceCards remain forced-dark slate chrome (Task 3); Quick status deliberately theme-aware.

--- a/docs/plans/_verify-mop-report.md
+++ b/docs/plans/_verify-mop-report.md
@@ -1,0 +1,27 @@
+---
+title: UI consistency medium mop
+description: Closed 3 MEDIUM verify findings + trivial LOW wifi spacing.
+updated: 2026-07-20
+branch: fix/ui-consistency
+---
+
+# Verify mop report
+
+## Status
+
+**DONE** — all 3 MEDIUM items from `_verify-ui-consistency.md` closed; trivial LOW wifi panel spacing fixed.
+
+## Fixes
+
+1. **SQM loading** — `sqm-section.tsx`: Loading paragraph → 3 Skeleton bars.
+2. **Input label** — `input.tsx`: embedded Label uses dense default (no `text-sm` / gray-700 override). Login already uses external Label with prominence — unchanged.
+3. **Card header icons** — speedtest `h-5`→`h-4`; SSH Keys / Alert Thresholds icons moved to CardHeader siblings with `h-4 w-4 text-gray-500 dark:text-gray-400`; gray-400-only CardHeader icons normalized on guest/schedule/radio/band-switch/mac-policy/split-tunnel.
+4. **LOW** — `wifi-wireless-panel.tsx`: `space-y-6`.
+
+## Tests
+
+`cd frontend && pnpm test` → **48 files, 262 tests passed**.
+
+## Commit / push
+
+Message: `fix(ui): close remaining consistency mediums`

--- a/docs/ui-theming.md
+++ b/docs/ui-theming.md
@@ -49,6 +49,10 @@ That way elements that only set size/weight (e.g. `className="text-sm"`) inherit
 
 Recharts ticks and tooltips cannot use Tailwind classes directly. Use CSS variables from `index.css` (`--chart-grid`, `--chart-axis`, `--chart-tooltip-*`) and pass them via `stroke` / `fill` / `contentStyle`.
 
+## Nested regions
+
+Inside a `Card`, use **`CardInset`** (`frontend/src/components/ui/card-inset.tsx`) for sub-groups — border only (`default`) or border + muted fill (`muted`). Do not nest a second shadowed `Card`.
+
 ## Borders in dark mode
 
 Surfaces such as **`dark:bg-gray-950`** are darker than Tailwind **`gray-800`** (`#1f2937`). Using **`dark:border-gray-800`** on those panels makes the border **lighter than the fill**, which reads as a harsh, almost white outline.

--- a/docs/ui-theming.md
+++ b/docs/ui-theming.md
@@ -1,13 +1,23 @@
 ---
 title: Frontend UI and theming
 description: ThemeProvider, dark class, Tailwind tokens, chart variables, contrast rules.
-updated: 2026-05-14
+updated: 2026-07-20
 tags: [docs, frontend, theming, tailwind]
 ---
 
 # Frontend UI & theming
 
 Short reference for Tailwind + dark mode in `frontend/`.
+
+## Card / Label / feedback contracts
+
+| Primitive | Default contract |
+|-----------|------------------|
+| **`CardTitle`** | `text-sm font-medium leading-none tracking-tight` + `text-gray-900 dark:text-white`. Prefer layout-only `className` overrides (`flex items-center gap-2`). Exceptions: Login hero (`text-2xl`); Setup step titles that are not `CardTitle`. |
+| **`Label`** | `text-xs font-medium text-gray-500 dark:text-gray-400`. Dense forms use this; Login may override to `text-sm font-medium` for prominence. |
+| **Loading** | `Skeleton` for card/page content. Spinners (`Loader2`) only for in-button/submit busy. |
+| **Empty** | `EmptyState` from `@/components/ui/empty-state`. |
+| **Load/display errors** | `InlineError` (`role="alert"`, `text-sm`, red border/bg light+dark pairs). Mutation success/failure stays on `sonner` toasts. |
 
 ## How theme works
 
@@ -29,7 +39,9 @@ That way elements that only set size/weight (e.g. `className="text-sm"`) inherit
 | Need                                | Pattern                                                                   |
 | ----------------------------------- | ------------------------------------------------------------------------- |
 | Default page/body copy              | Omit text color; inherit from `body`                                      |
-| Card titles                         | Prefer `CardTitle` / existing primitives (already include `dark:` pairs)  |
+| Card titles                         | Use `CardTitle` (compact `text-sm` default; see contracts above)          |
+| Form field labels                   | Use `Label` (or identical classes)                                        |
+| Inline load/display errors          | Use `InlineError`                                                         |
 | Secondary / hint text               | `text-gray-500 dark:text-gray-400` or `text-gray-600 dark:text-gray-300`  |
 | Primary emphasis on colored surface | Ensure both light and dark classes (e.g. `text-gray-900 dark:text-white`) |
 

--- a/docs/ui-theming.md
+++ b/docs/ui-theming.md
@@ -1,7 +1,7 @@
 ---
 title: Frontend UI and theming
 description: ThemeProvider, dark class, Tailwind tokens, chart variables, contrast rules.
-updated: 2026-07-20
+updated: 2026-07-21
 tags: [docs, frontend, theming, tailwind]
 ---
 
@@ -51,7 +51,25 @@ Recharts ticks and tooltips cannot use Tailwind classes directly. Use CSS variab
 
 ## Nested regions
 
-Inside a `Card`, use **`CardInset`** (`frontend/src/components/ui/card-inset.tsx`) for sub-groups — border only (`default`) or border + muted fill (`muted`). Do not nest a second shadowed `Card`.
+Inside a `Card`, use **`CardInset`** (`frontend/src/components/ui/card-inset.tsx`) for sub-groups — border only (`default`) or border + muted fill (`muted`). Do not nest a second shadowed `Card`. Prefer `CardInset` over hand-rolled `rounded-lg border p-3/4` nests on the card plane. Keep semantic alert/banner boxes (amber/red/blue health) as custom surfaces — not `CardInset`.
+
+## Form density
+
+| Tier | Height | When |
+|------|--------|------|
+| **Form rows** | Default control height (`Input` / `SelectTrigger` / submit `Button` = **`h-10`**) | Labeled fields, add/save rows next to `Input` |
+| **Dense chrome** | `Button size="sm"` (and icon rows) | Logs filters, page header actions, service action icon rows, quick actions — **not** form rows with labeled Inputs |
+
+`SelectTrigger` default is **`h-10`** with light `border-gray-300` and dark `border-white/10` (card-plane consistency). Do not leave form submits at `size="sm"` beside default Inputs.
+
+## Badge exceptions
+
+| Exception | Where | Why |
+|-----------|--------|-----|
+| **`LogsLevelBadge`** | `logs-level-badge.tsx` | Dense uppercase terminal chips; parallel to `Badge` by design |
+| **Dashboard `SourceCard` status pill** | `dashboard-page.tsx` | Forced-dark topology card; custom chip, not `Badge` |
+
+Elsewhere prefer `Badge` variants (`success` / `destructive` / `default` / `secondary` / `outline` / `warning`) over hand-rolled `bg-green-*` / `bg-red-*` / `bg-blue-*` className overrides.
 
 ## Borders in dark mode
 

--- a/frontend/src/components/clients/client-row.tsx
+++ b/frontend/src/components/clients/client-row.tsx
@@ -47,13 +47,13 @@ export function ClientRow({ client, isBlocked, hasReservation, onReserveIP }: Cl
           )}
         </div>
       </td>
-      <td className="hidden py-3 pr-4 text-sm text-gray-500 md:table-cell">
+      <td className="hidden py-3 pr-4 text-sm text-gray-500 dark:text-gray-400 md:table-cell">
         {client.interface_name}
       </td>
-      <td className="hidden py-3 pr-4 text-sm text-gray-500 lg:table-cell">
+      <td className="hidden py-3 pr-4 text-sm text-gray-500 dark:text-gray-400 lg:table-cell">
         {connectedSince ?? '—'}
       </td>
-      <td className="py-3 pr-4 text-sm text-gray-500">
+      <td className="py-3 pr-4 text-sm text-gray-500 dark:text-gray-400">
         <div className="text-xs">
           <span className="text-blue-600 dark:text-blue-400">↓ {formatBytes(client.rx_bytes)}</span>
           {' / '}

--- a/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
+++ b/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
@@ -12,7 +12,7 @@ export function ClientsDhcpReservationsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Static IP Reservations</CardTitle>
-        <BookmarkPlus className="h-4 w-4 text-gray-500" />
+        <BookmarkPlus className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {!reservations || reservations.length === 0 ? (
@@ -22,10 +22,10 @@ export function ClientsDhcpReservationsCard() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-200 text-left dark:border-gray-700">
-                  <th className="pb-2 font-medium text-gray-500">Hostname</th>
-                  <th className="pb-2 font-medium text-gray-500">MAC</th>
-                  <th className="pb-2 font-medium text-gray-500">IP</th>
-                  <th className="pb-2 text-right font-medium text-gray-500">Actions</th>
+                  <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">Hostname</th>
+                  <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">MAC</th>
+                  <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">IP</th>
+                  <th className="pb-2 text-right font-medium text-gray-500 dark:text-gray-400">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -35,7 +35,7 @@ export function ClientsDhcpReservationsCard() {
                     className="border-b border-gray-100 last:border-0 dark:border-white/[0.08]"
                   >
                     <td className="py-2 pr-4 text-gray-900 dark:text-white">{r.name}</td>
-                    <td className="py-2 pr-4 font-mono text-xs text-gray-500">{r.mac}</td>
+                    <td className="py-2 pr-4 font-mono text-xs text-gray-500 dark:text-gray-400">{r.mac}</td>
                     <td className="py-2 pr-4 text-gray-700 dark:text-gray-300">{r.ip}</td>
                     <td className="py-2 text-right">
                       <Button

--- a/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
+++ b/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
@@ -10,7 +10,7 @@ export function ClientsDhcpReservationsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Static IP Reservations</CardTitle>
+        <CardTitle>Static IP Reservations</CardTitle>
         <BookmarkPlus className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
+++ b/frontend/src/components/clients/clients-dhcp-reservations-card.tsx
@@ -1,6 +1,7 @@
 import { BookmarkPlus, Trash2 } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useDHCPReservations, useDeleteDHCPReservation } from '@/hooks/use-network';
 
 export function ClientsDhcpReservationsCard() {
@@ -15,10 +16,7 @@ export function ClientsDhcpReservationsCard() {
       </CardHeader>
       <CardContent>
         {!reservations || reservations.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            No static reservations. Use the bookmark icon next to a connected client to reserve its
-            IP.
-          </p>
+          <EmptyState message="No static reservations. Use the bookmark icon next to a connected client to reserve its IP." />
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">

--- a/frontend/src/components/clients/reserve-ip-form.tsx
+++ b/frontend/src/components/clients/reserve-ip-form.tsx
@@ -71,10 +71,10 @@ export function ReserveIpForm({ initial, onCancel }: ReserveIpFormProps) {
           ) : null}
         </div>
         <input type="hidden" {...register('mac')} />
-        <Button type="submit" size="sm" disabled={addReservation.isPending}>
+        <Button type="submit" disabled={addReservation.isPending}>
           {addReservation.isPending ? 'Saving…' : 'Save'}
         </Button>
-        <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
+        <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
       </div>

--- a/frontend/src/components/layout/header-notifications-menu.tsx
+++ b/frontend/src/components/layout/header-notifications-menu.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { Bell } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useAlerts } from '@/hooks/use-alerts';
 import { headerAlertSeverityVariant } from './header-alert-severity';
 import { formatAlertTime } from './header-format-alert-time';
@@ -50,9 +51,7 @@ export function HeaderNotificationsMenu() {
           </div>
           <div className="max-h-72 overflow-y-auto">
             {alerts.length === 0 ? (
-              <div className="px-3 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
-                No notifications
-              </div>
+              <EmptyState message="No notifications" />
             ) : (
               alerts.slice(0, 20).map((alert) => (
                 <div

--- a/frontend/src/components/layout/header-router-status.tsx
+++ b/frontend/src/components/layout/header-router-status.tsx
@@ -18,8 +18,8 @@ export function HeaderRouterStatus({ systemInfo, systemError }: HeaderRouterStat
       <span
         className={`inline-block h-2 w-2 rounded-full ${
           isConnected
-            ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]'
-            : 'bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.6)]'
+            ? 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.6)] dark:bg-emerald-400'
+            : 'bg-red-500 shadow-[0_0_6px_rgba(239,68,68,0.6)] dark:bg-red-400'
         }`}
         title={isConnected ? `Connected to ${systemInfo?.hostname ?? 'router'}` : 'Connection lost'}
       />

--- a/frontend/src/components/layout/lazy-page-boundary.tsx
+++ b/frontend/src/components/layout/lazy-page-boundary.tsx
@@ -8,7 +8,7 @@ export function LazyPageBoundary({ children }: { children: React.ReactNode }) {
     <ErrorBoundary>
       <Suspense
         fallback={
-          <div className="space-y-4 p-4 sm:p-6" aria-busy="true" aria-label="Loading page">
+          <div className="space-y-4" aria-busy="true" aria-label="Loading page">
             <Skeleton className="h-8 w-48 max-w-full" />
             <Skeleton className="h-4 w-full max-w-md" />
             <div className="grid gap-3 sm:grid-cols-2">

--- a/frontend/src/components/ui/__tests__/card.test.tsx
+++ b/frontend/src/components/ui/__tests__/card.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CardTitle } from '../card';
+
+describe('CardTitle', () => {
+  it('uses compact title defaults', () => {
+    render(<CardTitle>Settings</CardTitle>);
+
+    const title = screen.getByRole('heading', { level: 3, name: 'Settings' });
+    expect(title.className).toContain('text-sm');
+    expect(title.className).toContain('font-medium');
+    expect(title.className).toContain('leading-none');
+    expect(title.className).toContain('tracking-tight');
+    expect(title.className).toContain('text-gray-900');
+    expect(title.className).toContain('dark:text-white');
+    expect(title.className).not.toContain('text-lg');
+    expect(title.className).not.toContain('font-semibold');
+  });
+
+  it('merges className overrides', () => {
+    render(<CardTitle className="flex items-center gap-2">With icon</CardTitle>);
+
+    const title = screen.getByRole('heading', { level: 3, name: 'With icon' });
+    expect(title.className).toContain('flex');
+    expect(title.className).toContain('items-center');
+    expect(title.className).toContain('gap-2');
+    expect(title.className).toContain('text-sm');
+  });
+});

--- a/frontend/src/components/ui/__tests__/inline-error.test.tsx
+++ b/frontend/src/components/ui/__tests__/inline-error.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { InlineError } from '../inline-error';
+
+describe('InlineError', () => {
+  it('exposes an alert with red light/dark chrome', () => {
+    render(<InlineError>Failed to load status</InlineError>);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Failed to load status');
+    expect(alert.className).toContain('text-sm');
+    expect(alert.className).toContain('border-red');
+    expect(alert.className).toContain('bg-red');
+    expect(alert.className).toContain('dark:border-red');
+    expect(alert.className).toContain('dark:bg-red');
+    expect(alert.className).toContain('text-red');
+    expect(alert.className).toContain('dark:text-red');
+  });
+
+  it('merges className overrides', () => {
+    render(<InlineError className="mt-2">Oops</InlineError>);
+
+    expect(screen.getByRole('alert').className).toContain('mt-2');
+  });
+});

--- a/frontend/src/components/ui/__tests__/label.test.tsx
+++ b/frontend/src/components/ui/__tests__/label.test.tsx
@@ -1,0 +1,31 @@
+import { createRef } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Label } from '../label';
+
+describe('Label', () => {
+  it('renders a label with secondary denseness defaults', () => {
+    render(<Label htmlFor="ssid">SSID</Label>);
+
+    const label = screen.getByText('SSID');
+    expect(label.tagName).toBe('LABEL');
+    expect(label).toHaveAttribute('for', 'ssid');
+    expect(label.className).toContain('text-xs');
+    expect(label.className).toContain('font-medium');
+    expect(label.className).toContain('text-gray-500');
+    expect(label.className).toContain('dark:text-gray-400');
+  });
+
+  it('forwards ref and merges className', () => {
+    const ref = createRef<HTMLLabelElement>();
+    render(
+      <Label ref={ref} className="text-sm font-medium">
+        Password
+      </Label>,
+    );
+
+    expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+    expect(ref.current?.className).toContain('text-sm');
+    expect(ref.current?.className).toContain('font-medium');
+  });
+});

--- a/frontend/src/components/ui/card-inset.tsx
+++ b/frontend/src/components/ui/card-inset.tsx
@@ -1,0 +1,30 @@
+// CardInset — nested region inside Card (no second shadow)
+// variants: default = border only; muted = border + bg-gray-50 dark:bg-gray-900/50
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/cn';
+
+const cardInsetVariants = cva('rounded-md border border-gray-200 p-3 dark:border-white/10', {
+  variants: {
+    variant: {
+      default: '',
+      muted: 'bg-gray-50 dark:bg-gray-900/50',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+export interface CardInsetProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardInsetVariants> {}
+
+const CardInset = forwardRef<HTMLDivElement, CardInsetProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div ref={ref} className={cn(cardInsetVariants({ variant }), className)} {...props} />
+  ),
+);
+CardInset.displayName = 'CardInset';
+
+export { CardInset, cardInsetVariants };

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -27,7 +27,7 @@ const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadingEleme
     <h3
       ref={ref}
       className={cn(
-        'text-lg font-semibold leading-none tracking-tight text-gray-900 dark:text-white',
+        'text-sm font-medium leading-none tracking-tight text-gray-900 dark:text-white',
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -43,7 +43,7 @@ const DialogContent = forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-gray-500 opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:pointer-events-none dark:text-gray-400 dark:ring-offset-gray-950">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm text-gray-500 dark:text-gray-400 opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:pointer-events-none dark:ring-offset-gray-950">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/frontend/src/components/ui/inline-error.tsx
+++ b/frontend/src/components/ui/inline-error.tsx
@@ -1,0 +1,19 @@
+import { type HTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/cn';
+
+const InlineError = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(
+        'rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+InlineError.displayName = 'InlineError';
+
+export { InlineError };

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,5 +1,6 @@
 import { type InputHTMLAttributes, forwardRef } from 'react';
 import { cn } from '@/lib/cn';
+import { Label } from '@/components/ui/label';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -9,12 +10,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, label, id, type, ...props }, ref) => (
     <div className="w-full">
       {label && (
-        <label
+        <Label
           htmlFor={id}
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           {label}
-        </label>
+        </Label>
       )}
       <input
         ref={ref}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -10,10 +10,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, label, id, type, ...props }, ref) => (
     <div className="w-full">
       {label && (
-        <Label
-          htmlFor={id}
-          className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
-        >
+        <Label htmlFor={id} className="mb-1 block">
           {label}
         </Label>
       )}

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import { type LabelHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/lib/cn';
+
+const Label = forwardRef<HTMLLabelElement, LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn('text-xs font-medium text-gray-500 dark:text-gray-400', className)}
+      {...props}
+    />
+  ),
+);
+Label.displayName = 'Label';
+
+export { Label };

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 shadow-sm ring-offset-white placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-100 dark:ring-offset-gray-950 dark:placeholder:text-gray-400',
+      'flex h-10 w-full items-center justify-between rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 shadow-sm ring-offset-white placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-white/10 dark:text-gray-100 dark:ring-offset-gray-950 dark:placeholder:text-gray-400',
       className,
     )}
     {...props}

--- a/frontend/src/components/wifi/captive-portal-card.tsx
+++ b/frontend/src/components/wifi/captive-portal-card.tsx
@@ -120,7 +120,7 @@ export function CaptivePortalCard() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Internet Access</CardTitle>
+          <CardTitle>Internet Access</CardTitle>
           <Globe className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent className="space-y-3">
@@ -141,7 +141,7 @@ export function CaptivePortalCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Internet Access</CardTitle>
+        <CardTitle>Internet Access</CardTitle>
         <Button
           size="sm"
           variant="ghost"

--- a/frontend/src/components/wifi/confirm-radio-disable-dialog.tsx
+++ b/frontend/src/components/wifi/confirm-radio-disable-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { AlertTriangle, Radio } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 import {
   Dialog,
   DialogContent,
@@ -102,12 +103,12 @@ export function ConfirmRadioDisableDialog({
           )}
 
           <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900">
-            <label
+            <Label
               htmlFor="confirm-input"
               className="block text-sm font-medium text-gray-900 dark:text-white"
             >
               Type <span className="font-mono font-bold">CONFIRM</span> to proceed
-            </label>
+            </Label>
             <input
               id="confirm-input"
               type="text"

--- a/frontend/src/components/wifi/dns-tools-card.tsx
+++ b/frontend/src/components/wifi/dns-tools-card.tsx
@@ -7,6 +7,7 @@ import {
   useDNSMode,
 } from '@/hooks/use-captive-portal';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardInset } from '@/components/ui/card-inset';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -70,7 +71,7 @@ export function DNSToolsCard() {
         ) : null}
 
         {/* Bypass status + actions */}
-        <div className="rounded-lg border p-3 dark:border-white/10">
+        <CardInset>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               {dnsBypassed ? (
@@ -112,7 +113,7 @@ export function DNSToolsCard() {
               </Button>
             )}
           </div>
-        </div>
+        </CardInset>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/wifi/dns-tools-card.tsx
+++ b/frontend/src/components/wifi/dns-tools-card.tsx
@@ -42,7 +42,7 @@ export function DNSToolsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DNS Configuration</CardTitle>
+        <CardTitle>DNS Configuration</CardTitle>
         <Button
           size="sm"
           variant="ghost"

--- a/frontend/src/components/wifi/repeater-wizard/configure-ap-step.tsx
+++ b/frontend/src/components/wifi/repeater-wizard/configure-ap-step.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { DialogFooter } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import type { RepeaterUpstreamConfig, RepeaterApFormConfig } from './types';
 import { mapScanEncryptionToUci } from './map-encryption';
 
@@ -85,12 +86,11 @@ export function RepeaterWizardConfigureApStep({
           {!apConfig.separateBandConfig && (
             <div className="space-y-3 rounded-lg border p-4">
               <div className="space-y-2">
-                <label
+                <Label
                   htmlFor="ap-ssid-shared"
-                  className="text-xs font-medium text-gray-600 dark:text-gray-400"
                 >
                   Network name (all bands)
-                </label>
+                </Label>
                 <Input
                   id="ap-ssid-shared"
                   value={apConfig.ssid}
@@ -100,12 +100,11 @@ export function RepeaterWizardConfigureApStep({
               </div>
 
               <div className="space-y-2">
-                <label
+                <Label
                   htmlFor="ap-encryption-shared"
-                  className="text-xs font-medium text-gray-600 dark:text-gray-400"
                 >
                   Encryption
-                </label>
+                </Label>
                 <Select
                   value={apConfig.encryption}
                   onValueChange={(val) =>
@@ -130,12 +129,11 @@ export function RepeaterWizardConfigureApStep({
 
               {apConfig.encryption !== 'none' && (
                 <div className="space-y-2">
-                  <label
+                  <Label
                     htmlFor="ap-key-shared"
-                    className="text-xs font-medium text-gray-600 dark:text-gray-400"
                   >
                     Password
-                  </label>
+                  </Label>
                   <Input
                     id="ap-key-shared"
                     type="password"
@@ -198,12 +196,11 @@ export function RepeaterWizardConfigureApStep({
                 <div key={ap.section} className="space-y-3 rounded-lg border p-4">
                   <p className="text-sm font-medium">{bandLabel(ap.band)}</p>
                   <div className="space-y-2">
-                    <label
-                      className="text-xs font-medium text-gray-600 dark:text-gray-400"
+                    <Label
                       htmlFor={`ap-ssid-${ap.section}`}
                     >
                       SSID
-                    </label>
+                    </Label>
                     <Input
                       id={`ap-ssid-${ap.section}`}
                       value={pb.ssid}
@@ -219,12 +216,11 @@ export function RepeaterWizardConfigureApStep({
                     />
                   </div>
                   <div className="space-y-2">
-                    <label
-                      className="text-xs font-medium text-gray-600 dark:text-gray-400"
+                    <Label
                       htmlFor={`ap-enc-${ap.section}`}
                     >
                       Encryption
-                    </label>
+                    </Label>
                     <Select
                       value={pb.encryption}
                       onValueChange={(val) =>
@@ -254,12 +250,11 @@ export function RepeaterWizardConfigureApStep({
                   </div>
                   {pb.encryption !== 'none' && (
                     <div className="space-y-2">
-                      <label
-                        className="text-xs font-medium text-gray-600 dark:text-gray-400"
+                      <Label
                         htmlFor={`ap-key-${ap.section}`}
                       >
                         Password
-                      </label>
+                      </Label>
                       <Input
                         id={`ap-key-${ap.section}`}
                         type="password"

--- a/frontend/src/components/wifi/repeater-wizard/configure-ap-step.tsx
+++ b/frontend/src/components/wifi/repeater-wizard/configure-ap-step.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select';
 import { DialogFooter } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
+import { CardInset } from '@/components/ui/card-inset';
 import type { RepeaterUpstreamConfig, RepeaterApFormConfig } from './types';
 import { mapScanEncryptionToUci } from './map-encryption';
 
@@ -55,7 +56,7 @@ export function RepeaterWizardConfigureApStep({
         </p>
       </div>
 
-      <div className="flex items-center justify-between rounded-lg border p-3">
+      <CardInset className="flex items-center justify-between">
         <div className="space-y-0.5">
           <span className="text-sm font-medium text-gray-900 dark:text-white">
             Same as upstream
@@ -79,12 +80,12 @@ export function RepeaterWizardConfigureApStep({
             }));
           }}
         />
-      </div>
+      </CardInset>
 
       {!apConfig.sameAsUpstream && (
         <>
           {!apConfig.separateBandConfig && (
-            <div className="space-y-3 rounded-lg border p-4">
+            <CardInset className="space-y-3 p-4">
               <div className="space-y-2">
                 <Label
                   htmlFor="ap-ssid-shared"
@@ -146,10 +147,10 @@ export function RepeaterWizardConfigureApStep({
                   )}
                 </div>
               )}
-            </div>
+            </CardInset>
           )}
 
-          <div className="flex items-center justify-between rounded-lg border p-3">
+          <CardInset className="flex items-center justify-between">
             <div className="space-y-0.5">
               <span className="text-sm font-medium text-gray-900 dark:text-white">
                 Different settings per radio
@@ -183,7 +184,7 @@ export function RepeaterWizardConfigureApStep({
                 });
               }}
             />
-          </div>
+          </CardInset>
 
           {apConfig.separateBandConfig &&
             (apConfigs ?? []).map((ap) => {
@@ -193,7 +194,7 @@ export function RepeaterWizardConfigureApStep({
                 key: '',
               };
               return (
-                <div key={ap.section} className="space-y-3 rounded-lg border p-4">
+                <CardInset key={ap.section} className="space-y-3 p-4">
                   <p className="text-sm font-medium">{bandLabel(ap.band)}</p>
                   <div className="space-y-2">
                     <Label
@@ -271,13 +272,13 @@ export function RepeaterWizardConfigureApStep({
                       />
                     </div>
                   )}
-                </div>
+                </CardInset>
               );
             })}
         </>
       )}
 
-      <div className="flex items-center justify-between rounded-lg border p-3">
+      <CardInset className="flex items-center justify-between">
         <div className="space-y-0.5">
           <span className="text-sm font-medium text-gray-900 dark:text-white">
             Allow Wi‑Fi on uplink radio
@@ -293,7 +294,7 @@ export function RepeaterWizardConfigureApStep({
           checked={allowApOnStaRadio}
           onChange={(e) => setAllowApOnStaRadio(e.target.checked)}
         />
-      </div>
+      </CardInset>
 
       <DialogFooter>
         <Button variant="outline" onClick={onBack}>

--- a/frontend/src/components/wifi/repeater-wizard/review-step.tsx
+++ b/frontend/src/components/wifi/repeater-wizard/review-step.tsx
@@ -37,7 +37,7 @@ export function RepeaterWizardReviewStep({
         <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Upstream Connection</h3>
         <div className="rounded-lg border p-3">
           <div className="flex items-center gap-2">
-            <Wifi className="h-4 w-4 text-gray-500" />
+            <Wifi className="h-4 w-4 text-gray-500 dark:text-gray-400" />
             <span className="text-sm font-medium">{upstream.ssid}</span>
             {selectedNetwork && <SecurityBadge encryption={selectedNetwork.encryption} />}
           </div>
@@ -46,7 +46,7 @@ export function RepeaterWizardReviewStep({
         <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Access Point</h3>
         <div className="rounded-lg border p-3">
           <div className="flex items-center gap-2">
-            <Radio className="h-4 w-4 text-gray-500" />
+            <Radio className="h-4 w-4 text-gray-500 dark:text-gray-400" />
             <span className="text-sm font-medium">{apSummaryLine}</span>
             <Badge variant="outline">
               {effectiveAPEncryption === 'none' ? 'Open' : effectiveAPEncryption.toUpperCase()}

--- a/frontend/src/components/wifi/repeater-wizard/select-upstream-step.tsx
+++ b/frontend/src/components/wifi/repeater-wizard/select-upstream-step.tsx
@@ -4,6 +4,7 @@ import type { WifiScanResult, GroupedScanNetwork } from '@shared/index';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { DialogFooter } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { SignalStrengthIcon } from '@/components/wifi/signal-strength-icon';
 import { SecurityBadge } from '@/components/wifi/security-badge';
 import { WifiScanList } from '@/pages/wifi/wifi-scan-list';
@@ -57,12 +58,11 @@ export function RepeaterWizardSelectUpstreamStep({
 
           {needsPassword && (
             <div className="space-y-2">
-              <label
+              <Label
                 htmlFor="upstream-password"
-                className="text-xs font-medium text-gray-600 dark:text-gray-400"
               >
                 Password
-              </label>
+              </Label>
               <Input
                 id="upstream-password"
                 type="password"

--- a/frontend/src/components/wifi/repeater-wizard/step-indicator.tsx
+++ b/frontend/src/components/wifi/repeater-wizard/step-indicator.tsx
@@ -30,7 +30,7 @@ export function RepeaterWizardStepIndicator({ step }: { step: RepeaterWizardStep
               >
                 {i + 1}
               </div>
-              <span className="text-xs text-gray-500">{LABELS[i]}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400">{LABELS[i]}</span>
             </div>
           </div>
         );

--- a/frontend/src/components/wifi/wifi-mode-card.tsx
+++ b/frontend/src/components/wifi/wifi-mode-card.tsx
@@ -26,7 +26,7 @@ export function WifiModeCard() {
     <>
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">WiFi Mode</CardTitle>
+          <CardTitle>WiFi Mode</CardTitle>
         </CardHeader>
         <CardContent>
           {isLoading ? (

--- a/frontend/src/components/wifi/wifi-qr-dialog.tsx
+++ b/frontend/src/components/wifi/wifi-qr-dialog.tsx
@@ -35,7 +35,7 @@ export function WifiQRDialog({ open, onOpenChange, ap }: WifiQRDialogProps) {
           <div className="rounded-lg bg-white p-4">
             <QRCodeSVG value={getWifiQRString(ap)} size={200} level="M" />
           </div>
-          <p className="text-center text-sm text-gray-500">
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400">
             Scan this QR code to connect to <strong>{ap.ssid}</strong>
           </p>
           <div className="text-center text-xs text-gray-400">

--- a/frontend/src/pages/clients/clients-connected-clients-card.tsx
+++ b/frontend/src/pages/clients/clients-connected-clients-card.tsx
@@ -34,7 +34,7 @@ export function ClientsConnectedClientsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">
+        <CardTitle>
           Connected Clients
           {clients && (
             <span className="ml-2 text-xs font-normal text-gray-500">

--- a/frontend/src/pages/clients/clients-connected-clients-card.tsx
+++ b/frontend/src/pages/clients/clients-connected-clients-card.tsx
@@ -37,12 +37,12 @@ export function ClientsConnectedClientsCard() {
         <CardTitle>
           Connected Clients
           {clients && (
-            <span className="ml-2 text-xs font-normal text-gray-500">
+            <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
               ({clients.length} device{clients.length !== 1 ? 's' : ''})
             </span>
           )}
         </CardTitle>
-        <Users className="h-4 w-4 text-gray-500" />
+        <Users className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         <ClientsSearchBar value={search} onChange={setSearch} />

--- a/frontend/src/pages/clients/clients-connected-table.tsx
+++ b/frontend/src/pages/clients/clients-connected-table.tsx
@@ -43,12 +43,12 @@ export function ClientsConnectedTable({
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200 text-left dark:border-gray-700">
-            <th className="pb-2 font-medium text-gray-500">Device</th>
-            <th className="pb-2 font-medium text-gray-500">IP Address</th>
-            <th className="hidden pb-2 font-medium text-gray-500 md:table-cell">Interface</th>
-            <th className="hidden pb-2 font-medium text-gray-500 lg:table-cell">Connected Since</th>
-            <th className="pb-2 font-medium text-gray-500">Traffic</th>
-            <th className="pb-2 text-right font-medium text-gray-500">Actions</th>
+            <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">Device</th>
+            <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">IP Address</th>
+            <th className="hidden pb-2 font-medium text-gray-500 dark:text-gray-400 md:table-cell">Interface</th>
+            <th className="hidden pb-2 font-medium text-gray-500 dark:text-gray-400 lg:table-cell">Connected Since</th>
+            <th className="pb-2 font-medium text-gray-500 dark:text-gray-400">Traffic</th>
+            <th className="pb-2 text-right font-medium text-gray-500 dark:text-gray-400">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/pages/clients/clients-connected-table.tsx
+++ b/frontend/src/pages/clients/clients-connected-table.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { ClientRow } from '@/components/clients/client-row';
 import type { Client } from '@shared/index';
 
@@ -31,9 +32,9 @@ export function ClientsConnectedTable({
 
   if (filtered.length === 0) {
     return (
-      <p className="py-4 text-center text-sm text-gray-500">
-        {hasSearch ? 'No clients match your search.' : 'No clients connected.'}
-      </p>
+      <EmptyState
+        message={hasSearch ? 'No clients match your search.' : 'No clients connected.'}
+      />
     );
   }
 

--- a/frontend/src/pages/clients/clients-page.tsx
+++ b/frontend/src/pages/clients/clients-page.tsx
@@ -3,7 +3,7 @@ import { ClientsDhcpReservationsCard } from '@/components/clients/clients-dhcp-r
 
 export function ClientsPage() {
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-6">
       <ClientsConnectedClientsCard />
       <ClientsDhcpReservationsCard />
     </div>

--- a/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
@@ -106,7 +106,7 @@ describe('DashboardPage', () => {
     expect(reachable.className).toMatch(/dark:text-emerald-400/);
     const vpnState = screen.getByText(/^(On|Off)$/);
     if (vpnState.textContent === 'Off') {
-      expect(vpnState.className).toMatch(/text-gray-500/);
+      expect(vpnState.className).toMatch(/text-gray-500 dark:text-gray-400/);
       expect(vpnState.className).toMatch(/dark:text-gray-400/);
     } else {
       expect(vpnState.className).toMatch(/text-emerald-600/);

--- a/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
@@ -101,6 +101,17 @@ describe('DashboardPage', () => {
       expect(screen.getByText('Quick status')).toBeInTheDocument();
       expect(screen.getByText('Reachable')).toBeInTheDocument();
     });
+    const reachable = screen.getByText('Reachable');
+    expect(reachable.className).toMatch(/text-emerald-600/);
+    expect(reachable.className).toMatch(/dark:text-emerald-400/);
+    const vpnState = screen.getByText(/^(On|Off)$/);
+    if (vpnState.textContent === 'Off') {
+      expect(vpnState.className).toMatch(/text-gray-500/);
+      expect(vpnState.className).toMatch(/dark:text-gray-400/);
+    } else {
+      expect(vpnState.className).toMatch(/text-emerald-600/);
+      expect(vpnState.className).toMatch(/dark:text-emerald-400/);
+    }
     expect(screen.getByRole('link', { name: /Device details and settings/i })).toHaveAttribute(
       'href',
       '/system',

--- a/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/dashboard-page.test.tsx
@@ -78,6 +78,16 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('forces dark SourceCard chrome for light-mode contrast', async () => {
+    renderDashboard();
+    const ethernet = await screen.findByRole('heading', { name: 'Ethernet (WAN)' });
+    const card = ethernet.closest('[class*="bg-slate-900"]');
+    expect(card).toBeTruthy();
+    expect(card?.className).toMatch(/border-slate-700/);
+    expect(card?.className).toMatch(/bg-slate-900/);
+    expect(ethernet.className).toMatch(/text-slate-100/);
+  });
+
   it('shows repeater details when WiFi is connected', async () => {
     renderDashboard();
     await waitFor(() => {

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -378,10 +378,10 @@ export function DashboardPage() {
         </SourceCard>
       </div>
 
-      <Card className="dark:border-slate-700 dark:bg-slate-900">
+      <Card>
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2">
-            <Monitor className="h-4 w-4 text-slate-400" />
+            <Monitor className="h-4 w-4 text-gray-500 dark:text-gray-400" />
             Quick status
           </CardTitle>
         </CardHeader>
@@ -399,7 +399,11 @@ export function DashboardPage() {
                 <div>
                   <span className="text-muted-foreground">Internet</span>
                   <p
-                    className={`mt-0.5 font-medium ${internetUp ? 'text-emerald-500' : 'text-red-500'}`}
+                    className={`mt-0.5 font-medium ${
+                      internetUp
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : 'text-red-600 dark:text-red-400'
+                    }`}
                   >
                     {internetUp ? 'Reachable' : 'Unreachable'}
                   </p>
@@ -409,13 +413,15 @@ export function DashboardPage() {
                   <div className="mt-0.5 flex items-center gap-1.5">
                     {vpnActive ? (
                       <>
-                        <Shield className="h-3.5 w-3.5 text-emerald-500" />
-                        <span className="font-medium text-emerald-500">On</span>
+                        <Shield className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                        <span className="font-medium text-emerald-600 dark:text-emerald-400">
+                          On
+                        </span>
                       </>
                     ) : (
                       <>
-                        <Shield className="h-3.5 w-3.5 text-slate-500" />
-                        <span className="font-medium text-slate-500">Off</span>
+                        <Shield className="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+                        <span className="font-medium text-gray-500 dark:text-gray-400">Off</span>
                       </>
                     )}
                   </div>

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -11,7 +11,6 @@ import {
 import { Link } from '@tanstack/react-router';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { EmptyState } from '@/components/ui/empty-state';
 import { TimezoneAlert } from '@/components/timezone-alert';
 import { useTopologyData } from '@/hooks/use-topology-data';
 import type { SourceDef } from '@/hooks/use-topology-data';
@@ -322,7 +321,7 @@ export function DashboardPage() {
               )}
             </>
           ) : (
-            <EmptyState message="No Ethernet WAN connection detected." />
+            <p className="text-slate-500">No Ethernet WAN connection detected.</p>
           )}
         </SourceCard>
 
@@ -397,7 +396,7 @@ export function DashboardPage() {
             <>
               <div className="grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
                 <div>
-                  <span className="text-muted-foreground">Internet</span>
+                  <span className="text-gray-500 dark:text-gray-400">Internet</span>
                   <p
                     className={`mt-0.5 font-medium ${
                       internetUp
@@ -409,7 +408,7 @@ export function DashboardPage() {
                   </p>
                 </div>
                 <div>
-                  <span className="text-muted-foreground">VPN</span>
+                  <span className="text-gray-500 dark:text-gray-400">VPN</span>
                   <div className="mt-0.5 flex items-center gap-1.5">
                     {vpnActive ? (
                       <>
@@ -427,17 +426,17 @@ export function DashboardPage() {
                   </div>
                 </div>
                 <div>
-                  <span className="text-muted-foreground">Devices on your network</span>
+                  <span className="text-gray-500 dark:text-gray-400">Devices on your network</span>
                   <p className="mt-0.5 font-medium">{allClients.length}</p>
                 </div>
                 <div>
-                  <span className="text-muted-foreground">Uptime</span>
+                  <span className="text-gray-500 dark:text-gray-400">Uptime</span>
                   <p className="mt-0.5 font-medium">
                     {sysInfo ? formatUptime(sysInfo.uptime_seconds) : '—'}
                   </p>
                 </div>
               </div>
-              <p className="mt-4 text-sm text-muted-foreground">
+              <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
                 <Link to="/system" className="underline-offset-4 hover:underline">
                   Device details and settings
                 </Link>{' '}

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -231,10 +231,10 @@ function SourceCard({
   children?: React.ReactNode;
 }) {
   return (
-    <Card className="dark:border-slate-700 dark:bg-slate-900">
+    <Card className="border-slate-700 bg-slate-900 text-slate-200">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-100">
             <Icon className="h-4 w-4 text-slate-400" />
             {title}
           </CardTitle>
@@ -256,9 +256,7 @@ function SourceCard({
           />
           {connected ? 'Connected' : 'Not connected'}
         </div>
-        {children && (
-          <div className="space-y-1 text-xs text-slate-500 dark:text-slate-500">{children}</div>
-        )}
+        {children && <div className="space-y-1 text-xs text-slate-500">{children}</div>}
       </CardContent>
     </Card>
   );
@@ -307,22 +305,18 @@ export function DashboardPage() {
             <>
               <div className="flex justify-between">
                 <span>Protocol</span>
-                <span className="uppercase text-slate-300 dark:text-slate-300">{wan.type}</span>
+                <span className="uppercase text-slate-300">{wan.type}</span>
               </div>
               {wan.ip_address && (
                 <div className="flex justify-between">
                   <span>IP</span>
-                  <span className="font-mono text-slate-300 dark:text-slate-300">
-                    {wan.ip_address}
-                  </span>
+                  <span className="font-mono text-slate-300">{wan.ip_address}</span>
                 </div>
               )}
               {wan.gateway && (
                 <div className="flex justify-between">
                   <span>Gateway</span>
-                  <span className="font-mono text-slate-300 dark:text-slate-300">
-                    {wan.gateway}
-                  </span>
+                  <span className="font-mono text-slate-300">{wan.gateway}</span>
                 </div>
               )}
             </>
@@ -336,21 +330,17 @@ export function DashboardPage() {
             <>
               <div className="flex justify-between">
                 <span>SSID</span>
-                <span className="max-w-[80px] truncate font-mono text-slate-300 dark:text-slate-300">
+                <span className="max-w-[80px] truncate font-mono text-slate-300">
                   {wifiConn.ssid}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span>Band</span>
-                <span className="uppercase text-slate-300 dark:text-slate-300">
-                  {wifiConn.band}
-                </span>
+                <span className="uppercase text-slate-300">{wifiConn.band}</span>
               </div>
               <div className="flex justify-between">
                 <span>Signal</span>
-                <span className="text-slate-300 dark:text-slate-300">
-                  {wifiConn.signal_percent}%
-                </span>
+                <span className="text-slate-300">{wifiConn.signal_percent}%</span>
               </div>
             </>
           ) : (
@@ -364,7 +354,7 @@ export function DashboardPage() {
               {usbTether?.detected && (
                 <div className="flex justify-between">
                   <span>Device</span>
-                  <span className="capitalize text-slate-300 dark:text-slate-300">
+                  <span className="capitalize text-slate-300">
                     {usbTether.device_type || 'Unknown'}
                   </span>
                 </div>
@@ -372,7 +362,7 @@ export function DashboardPage() {
               {usbDisplayIp ? (
                 <div className="flex justify-between">
                   <span>IP</span>
-                  <span className="font-mono text-slate-300 dark:text-slate-300">{usbDisplayIp}</span>
+                  <span className="font-mono text-slate-300">{usbDisplayIp}</span>
                 </div>
               ) : null}
               {tetherUp && !usbTether?.detected && !usbDisplayIp ? (

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -11,6 +11,7 @@ import {
 import { Link } from '@tanstack/react-router';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { TimezoneAlert } from '@/components/timezone-alert';
 import { useTopologyData } from '@/hooks/use-topology-data';
 import type { SourceDef } from '@/hooks/use-topology-data';
@@ -321,7 +322,7 @@ export function DashboardPage() {
               )}
             </>
           ) : (
-            <p className="text-slate-500">No Ethernet WAN connection detected.</p>
+            <EmptyState message="No Ethernet WAN connection detected." />
           )}
         </SourceCard>
 

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -234,7 +234,7 @@ function SourceCard({
     <Card className="border-slate-700 bg-slate-900 text-slate-200">
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium text-slate-100">
+          <CardTitle className="flex items-center gap-2 text-slate-100">
             <Icon className="h-4 w-4 text-slate-400" />
             {title}
           </CardTitle>
@@ -379,7 +379,7 @@ export function DashboardPage() {
 
       <Card className="dark:border-slate-700 dark:bg-slate-900">
         <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <CardTitle className="flex items-center gap-2">
             <Monitor className="h-4 w-4 text-slate-400" />
             Quick status
           </CardTitle>

--- a/frontend/src/pages/dashboard/dashboard-page.tsx
+++ b/frontend/src/pages/dashboard/dashboard-page.tsx
@@ -378,11 +378,9 @@ export function DashboardPage() {
       </div>
 
       <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2">
-            <Monitor className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-            Quick status
-          </CardTitle>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle>Quick status</CardTitle>
+          <Monitor className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           {loading ? (

--- a/frontend/src/pages/dashboard/network-chart.tsx
+++ b/frontend/src/pages/dashboard/network-chart.tsx
@@ -19,7 +19,11 @@ export function NetworkChart() {
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Network Throughput</CardTitle>
         <div className="flex items-center gap-2">
-          <span className={`h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-400'}`} />
+          <span
+            className={`h-2 w-2 rounded-full ${
+              connected ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-gray-400 dark:bg-gray-600'
+            }`}
+          />
         </div>
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/dashboard/network-chart.tsx
+++ b/frontend/src/pages/dashboard/network-chart.tsx
@@ -17,7 +17,7 @@ export function NetworkChart() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Network Throughput</CardTitle>
+        <CardTitle>Network Throughput</CardTitle>
         <div className="flex items-center gap-2">
           <span className={`h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-400'}`} />
         </div>

--- a/frontend/src/pages/dashboard/quick-actions.tsx
+++ b/frontend/src/pages/dashboard/quick-actions.tsx
@@ -60,7 +60,7 @@ export function QuickActions() {
     <>
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Quick Actions</CardTitle>
+          <CardTitle>Quick Actions</CardTitle>
         </CardHeader>
         <CardContent>
           <QuickActionsButtonRow

--- a/frontend/src/pages/login/login-form-fields.tsx
+++ b/frontend/src/pages/login/login-form-fields.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { InlineError } from '@/components/ui/inline-error';
+import { Label } from '@/components/ui/label';
 import type { LoginFormValues } from '@/pages/login/login-schema';
 
 type LoginFormFieldsProps = {
@@ -21,9 +22,9 @@ export function LoginFormFields({
   return (
     <>
       <div className="space-y-2">
-        <label htmlFor="password" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        <Label htmlFor="password" className="text-sm font-medium text-gray-700 dark:text-gray-300">
           Password
-        </label>
+        </Label>
         <Input
           id="password"
           type="password"
@@ -54,9 +55,9 @@ export function LoginFormFields({
           className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
           {...register('rememberMe')}
         />
-        <label htmlFor="remember-me" className="text-sm text-gray-600 dark:text-gray-400">
+        <Label htmlFor="remember-me" className="text-sm text-gray-600 dark:text-gray-400">
           Remember me
-        </label>
+        </Label>
       </div>
 
       <Button type="submit" className="w-full" disabled={isSubmitting}>

--- a/frontend/src/pages/login/login-form-fields.tsx
+++ b/frontend/src/pages/login/login-form-fields.tsx
@@ -2,6 +2,7 @@ import type { UseFormRegister } from 'react-hook-form';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { InlineError } from '@/components/ui/inline-error';
 import type { LoginFormValues } from '@/pages/login/login-schema';
 
 type LoginFormFieldsProps = {
@@ -40,13 +41,10 @@ export function LoginFormFields({
       </div>
 
       {rootMessage ? (
-        <div
-          className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/50 dark:text-red-400"
-          role="alert"
-        >
+        <InlineError className="flex items-center gap-2">
           <AlertCircle className="h-4 w-4 shrink-0" />
           <span>{rootMessage}</span>
-        </div>
+        </InlineError>
       ) : null}
 
       <div className="flex items-center gap-2">

--- a/frontend/src/pages/logs/logs-constants.ts
+++ b/frontend/src/pages/logs/logs-constants.ts
@@ -20,14 +20,14 @@ export const LOG_LEVEL_FILTERS: { label: string; value: string }[] = [
 ];
 
 export const LOG_LEVEL_COLORS: Record<string, string> = {
-  emerg: 'bg-red-600 text-white',
-  alert: 'bg-red-500 text-white',
-  crit: 'bg-red-500 text-white',
-  err: 'bg-red-400 text-white',
-  warning: 'bg-amber-400 text-amber-950',
-  notice: 'bg-green-400 text-green-950',
-  info: 'bg-blue-400 text-white',
-  debug: 'bg-gray-400 text-gray-950',
+  emerg: 'bg-red-600 text-white dark:bg-red-700 dark:text-red-100',
+  alert: 'bg-red-500 text-white dark:bg-red-600 dark:text-red-100',
+  crit: 'bg-red-500 text-white dark:bg-red-600 dark:text-red-100',
+  err: 'bg-red-400 text-white dark:bg-red-500 dark:text-red-50',
+  warning: 'bg-amber-400 text-amber-950 dark:bg-amber-500 dark:text-amber-950',
+  notice: 'bg-emerald-400 text-emerald-950 dark:bg-emerald-500 dark:text-emerald-950',
+  info: 'bg-blue-400 text-white dark:bg-blue-500 dark:text-blue-50',
+  debug: 'bg-gray-400 text-gray-950 dark:bg-gray-500 dark:text-gray-950',
 };
 
 export const defaultLogsFilters: LogsFilterFormValues = {

--- a/frontend/src/pages/logs/logs-level-badge.tsx
+++ b/frontend/src/pages/logs/logs-level-badge.tsx
@@ -1,8 +1,10 @@
 import { LOG_LEVEL_COLORS } from './logs-constants';
 
+/** Dense uppercase chips for log terminal; ui/Badge (rounded-full, pastel) not visual parity. */
 export function LogsLevelBadge({ level }: { level: string }) {
   if (!level) return null;
-  const color = LOG_LEVEL_COLORS[level] ?? 'bg-gray-300 text-gray-800';
+  const color =
+    LOG_LEVEL_COLORS[level] ?? 'bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-100';
   return (
     <span
       className={`mr-2 inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase leading-none ${color}`}

--- a/frontend/src/pages/logs/logs-page.tsx
+++ b/frontend/src/pages/logs/logs-page.tsx
@@ -70,7 +70,7 @@ export function LogsPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>System Logs</CardTitle>
-          <ScrollText className="h-4 w-4 text-gray-500" />
+          <ScrollText className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <LogsToolbar

--- a/frontend/src/pages/logs/logs-page.tsx
+++ b/frontend/src/pages/logs/logs-page.tsx
@@ -69,7 +69,7 @@ export function LogsPage() {
     <div className="space-y-6">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">System Logs</CardTitle>
+          <CardTitle>System Logs</CardTitle>
           <ScrollText className="h-4 w-4 text-gray-500" />
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/logs/logs-text-view.tsx
+++ b/frontend/src/pages/logs/logs-text-view.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import type { LogEntry, LogResponse } from '@shared/index';
 import { LogsLevelBadge } from './logs-level-badge';
 
@@ -28,6 +29,10 @@ export function LogsTextView({
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-3/4" />
         </div>
+      ) : filteredLines.length === 0 ? (
+        <EmptyState
+          message={lineFilter ? 'No log entries matching filter' : 'No log entries'}
+        />
       ) : (
         <pre
           ref={logRef}
@@ -35,18 +40,12 @@ export function LogsTextView({
           className="max-h-[500px] overflow-y-auto rounded-md bg-gray-950 p-4 font-mono text-xs leading-relaxed text-green-400"
         >
           <code>
-            {filteredLines.length > 0 ? (
-              filteredLines.map((entry, i) => (
-                <div key={i}>
-                  <LogsLevelBadge level={entry.level} />
-                  {entry.line}
-                </div>
-              ))
-            ) : (
-              <span className="text-gray-500">
-                No log entries{lineFilter ? ' matching filter' : ''}
-              </span>
-            )}
+            {filteredLines.map((entry, i) => (
+              <div key={i}>
+                <LogsLevelBadge level={entry.level} />
+                {entry.line}
+              </div>
+            ))}
           </code>
         </pre>
       )}

--- a/frontend/src/pages/logs/logs-text-view.tsx
+++ b/frontend/src/pages/logs/logs-text-view.tsx
@@ -51,7 +51,7 @@ export function LogsTextView({
       )}
 
       {!isLoading && logs && (
-        <p className="mt-2 text-xs text-gray-500">
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
           {filteredLines.length}
           {lineFilter ? ` / ${logs.total}` : ''} lines
         </p>

--- a/frontend/src/pages/logs/logs-toolbar-level-filters.tsx
+++ b/frontend/src/pages/logs/logs-toolbar-level-filters.tsx
@@ -13,7 +13,7 @@ export function LogsToolbarLevelFilters({ setValue, levelFilter }: LogsToolbarLe
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2">
       <Filter className="h-4 w-4 text-gray-400" />
-      <span className="text-xs text-gray-500">Level:</span>
+      <span className="text-xs text-gray-500 dark:text-gray-400">Level:</span>
       {LOG_LEVEL_FILTERS.map((lf) => (
         <Button
           key={lf.value}

--- a/frontend/src/pages/network/clients-table.tsx
+++ b/frontend/src/pages/network/clients-table.tsx
@@ -27,17 +27,17 @@ export function ClientsTable({ clients, blockedMacs = [] }: ClientsTableProps) {
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-200 dark:border-gray-700">
-            <th className="pb-2 text-left font-medium text-gray-500">Name</th>
-            <th className="pb-2 text-left font-medium text-gray-500">IP</th>
-            <th className="hidden pb-2 text-left font-medium text-gray-500 md:table-cell">MAC</th>
-            <th className="hidden pb-2 text-left font-medium text-gray-500 lg:table-cell">
+            <th className="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">Name</th>
+            <th className="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">IP</th>
+            <th className="hidden pb-2 text-left font-medium text-gray-500 dark:text-gray-400 md:table-cell">MAC</th>
+            <th className="hidden pb-2 text-left font-medium text-gray-500 dark:text-gray-400 lg:table-cell">
               Interface
             </th>
-            <th className="hidden pb-2 text-left font-medium text-gray-500 md:table-cell">
+            <th className="hidden pb-2 text-left font-medium text-gray-500 dark:text-gray-400 md:table-cell">
               Connected Since
             </th>
-            <th className="pb-2 text-right font-medium text-gray-500">Traffic</th>
-            <th className="pb-2 text-right font-medium text-gray-500">Actions</th>
+            <th className="pb-2 text-right font-medium text-gray-500 dark:text-gray-400">Traffic</th>
+            <th className="pb-2 text-right font-medium text-gray-500 dark:text-gray-400">Actions</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100 dark:divide-gray-800">

--- a/frontend/src/pages/network/data-usage-budget-editor.tsx
+++ b/frontend/src/pages/network/data-usage-budget-editor.tsx
@@ -59,7 +59,7 @@ export function DataUsageBudgetEditor({ ifaceName, current, onSave }: DataUsageB
           </span>
         ) : null}
       </div>
-      <span className="pb-2 text-xs text-gray-500">GB/month, warn at</span>
+      <span className="pb-2 text-xs text-gray-500 dark:text-gray-400">GB/month, warn at</span>
       <div className="flex flex-col gap-0.5">
         <Input
           className="h-7 w-16 text-sm"
@@ -74,7 +74,7 @@ export function DataUsageBudgetEditor({ ifaceName, current, onSave }: DataUsageB
           </span>
         ) : null}
       </div>
-      <span className="pb-2 text-xs text-gray-500">%</span>
+      <span className="pb-2 text-xs text-gray-500 dark:text-gray-400">%</span>
       <Button type="submit" size="sm" className="h-7 text-xs">
         Save
       </Button>

--- a/frontend/src/pages/network/data-usage-budget-editor.tsx
+++ b/frontend/src/pages/network/data-usage-budget-editor.tsx
@@ -47,7 +47,7 @@ export function DataUsageBudgetEditor({ ifaceName, current, onSave }: DataUsageB
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-wrap items-end gap-2" noValidate>
       <div className="flex flex-col gap-0.5">
         <Input
-          className="h-7 w-24 text-sm"
+          className="w-24"
           placeholder="Limit (GB)"
           aria-invalid={errors.limit_gb ? 'true' : undefined}
           aria-describedby={errors.limit_gb ? `budget-limit-${ifaceName}` : undefined}
@@ -62,7 +62,7 @@ export function DataUsageBudgetEditor({ ifaceName, current, onSave }: DataUsageB
       <span className="pb-2 text-xs text-gray-500 dark:text-gray-400">GB/month, warn at</span>
       <div className="flex flex-col gap-0.5">
         <Input
-          className="h-7 w-16 text-sm"
+          className="w-16"
           placeholder="80"
           aria-invalid={errors.warning_threshold_pct ? 'true' : undefined}
           aria-describedby={errors.warning_threshold_pct ? `budget-warn-${ifaceName}` : undefined}
@@ -75,9 +75,7 @@ export function DataUsageBudgetEditor({ ifaceName, current, onSave }: DataUsageB
         ) : null}
       </div>
       <span className="pb-2 text-xs text-gray-500 dark:text-gray-400">%</span>
-      <Button type="submit" size="sm" className="h-7 text-xs">
-        Save
-      </Button>
+      <Button type="submit">Save</Button>
     </form>
   );
 }

--- a/frontend/src/pages/network/data-usage-interface-card.tsx
+++ b/frontend/src/pages/network/data-usage-interface-card.tsx
@@ -37,21 +37,21 @@ export function DataUsageInterfaceCard({ iface, budget }: DataUsageInterfaceCard
 
       <div className="grid grid-cols-3 gap-3 text-sm">
         <div>
-          <p className="mb-0.5 text-xs text-gray-500">Today</p>
+          <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">Today</p>
           <p className="font-mono">{formatBytes(iface.today.rx_bytes + iface.today.tx_bytes)}</p>
           <p className="text-xs text-gray-400">
             ↓{formatBytes(iface.today.rx_bytes)} ↑{formatBytes(iface.today.tx_bytes)}
           </p>
         </div>
         <div>
-          <p className="mb-0.5 text-xs text-gray-500">This Month</p>
+          <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">This Month</p>
           <p className="font-mono">{formatBytes(iface.month.rx_bytes + iface.month.tx_bytes)}</p>
           <p className="text-xs text-gray-400">
             ↓{formatBytes(iface.month.rx_bytes)} ↑{formatBytes(iface.month.tx_bytes)}
           </p>
         </div>
         <div>
-          <p className="mb-0.5 text-xs text-gray-500">Total</p>
+          <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">Total</p>
           <p className="font-mono">{formatBytes(iface.total.rx_bytes + iface.total.tx_bytes)}</p>
           <p className="text-xs text-gray-400">
             ↓{formatBytes(iface.total.rx_bytes)} ↑{formatBytes(iface.total.tx_bytes)}

--- a/frontend/src/pages/network/data-usage-interface-card.tsx
+++ b/frontend/src/pages/network/data-usage-interface-card.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { CardInset } from '@/components/ui/card-inset';
 import { useResetDataUsage } from '@/hooks/use-data-usage';
 import type { DataBudget, DataUsageInterface } from '@shared/index';
 import { formatBytes } from '@/lib/utils';
@@ -15,7 +16,7 @@ export function DataUsageInterfaceCard({ iface, budget }: DataUsageInterfaceCard
   const resetMutation = useResetDataUsage();
 
   return (
-    <div className="space-y-2 rounded-md border p-3">
+    <CardInset className="space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">{iface.label}</span>
         <div className="flex items-center gap-2">
@@ -66,6 +67,6 @@ export function DataUsageInterfaceCard({ iface, budget }: DataUsageInterfaceCard
           label="Monthly budget"
         />
       )}
-    </div>
+    </CardInset>
   );
 }

--- a/frontend/src/pages/network/data-usage-section.tsx
+++ b/frontend/src/pages/network/data-usage-section.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { BarChart2, RefreshCw, Settings } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { useDataUsage, useDataBudget, useSetDataBudget } from '@/hooks/use-data-usage';
 import type { DataBudget } from '@shared/index';
@@ -14,20 +15,30 @@ export function DataUsageSection() {
   const setBudgetMutation = useSetDataBudget();
   const [editingBudget, setEditingBudget] = useState<string | null>(null);
 
-  if (isLoading) return null;
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle>Data Usage</CardTitle>
+          <BarChart2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
 
   if (!status?.available) {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Data Usage</CardTitle>
-          <BarChart2 className="h-4 w-4 text-gray-500" />
+          <BarChart2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-gray-500">
-            Install the <strong>Data Usage (vnstat)</strong> service to track cumulative traffic per
-            interface with budget warnings.
-          </p>
+          <EmptyState message="Install the Data Usage (vnstat) service to track cumulative traffic per interface with budget warnings." />
         </CardContent>
       </Card>
     );
@@ -50,7 +61,7 @@ export function DataUsageSection() {
           <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => void refetch()}>
             <RefreshCw className="h-3.5 w-3.5" />
           </Button>
-          <BarChart2 className="h-4 w-4 text-gray-500" />
+          <BarChart2 className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -70,7 +81,7 @@ export function DataUsageSection() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 gap-1 text-xs text-gray-500"
+                  className="h-6 gap-1 text-xs text-gray-500 dark:text-gray-400"
                   onClick={() => setEditingBudget(iface.name)}
                 >
                   <Settings className="h-3 w-3" />

--- a/frontend/src/pages/network/data-usage-section.tsx
+++ b/frontend/src/pages/network/data-usage-section.tsx
@@ -20,7 +20,7 @@ export function DataUsageSection() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Data Usage</CardTitle>
+          <CardTitle>Data Usage</CardTitle>
           <BarChart2 className="h-4 w-4 text-gray-500" />
         </CardHeader>
         <CardContent>
@@ -45,7 +45,7 @@ export function DataUsageSection() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Data Usage</CardTitle>
+        <CardTitle>Data Usage</CardTitle>
         <div className="flex items-center gap-1">
           <Button variant="ghost" size="sm" className="h-6 w-6 p-0" onClick={() => void refetch()}>
             <RefreshCw className="h-3.5 w-3.5" />

--- a/frontend/src/pages/network/data-usage-usage-bar.tsx
+++ b/frontend/src/pages/network/data-usage-usage-bar.tsx
@@ -11,7 +11,7 @@ export function DataUsageUsageBar({ used, limit, label }: UsageBarProps) {
   const color = pct >= 90 ? 'bg-red-500' : pct >= 80 ? 'bg-yellow-500' : 'bg-blue-500';
   return (
     <div className="space-y-1">
-      <div className="flex justify-between text-xs text-gray-500">
+      <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400">
         <span>{label}</span>
         <span>
           {formatBytes(used)} / {formatBytes(limit)} ({pct.toFixed(0)}%)

--- a/frontend/src/pages/network/ddns-card.tsx
+++ b/frontend/src/pages/network/ddns-card.tsx
@@ -71,7 +71,7 @@ export function DdnsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Dynamic DNS (DDNS)</CardTitle>
-        <RefreshCw className="h-4 w-4 text-gray-500" />
+        <RefreshCw className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {ddnsConfigLoading ? (

--- a/frontend/src/pages/network/ddns-card.tsx
+++ b/frontend/src/pages/network/ddns-card.tsx
@@ -70,7 +70,7 @@ export function DdnsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Dynamic DNS (DDNS)</CardTitle>
+        <CardTitle>Dynamic DNS (DDNS)</CardTitle>
         <RefreshCw className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/ddns-enabled-fields.tsx
+++ b/frontend/src/pages/network/ddns-enabled-fields.tsx
@@ -6,6 +6,7 @@ import {
   type UseFormSetValue,
 } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/cn';
 import {
   Select,
@@ -34,7 +35,7 @@ export function DdnsEnabledFields({
   return (
     <>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Provider</label>
+        <Label>Provider</Label>
         <Controller
           control={control}
           name="service"
@@ -69,7 +70,7 @@ export function DdnsEnabledFields({
       </div>
       {service === 'custom' && (
         <div className="space-y-1">
-          <label className="text-xs text-gray-500 dark:text-gray-400">Update URL</label>
+          <Label>Update URL</Label>
           <textarea
             rows={3}
             placeholder="https://example.com/update?hostname=[DOMAIN]&myip=[IP]"
@@ -93,7 +94,7 @@ export function DdnsEnabledFields({
         </div>
       )}
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Domain</label>
+        <Label>Domain</Label>
         <Input
           placeholder="myrouter.duckdns.org"
           aria-invalid={errors.domain ? 'true' : undefined}
@@ -108,16 +109,16 @@ export function DdnsEnabledFields({
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1">
-          <label className="text-xs text-gray-500">Username / Token</label>
+          <Label>Username / Token</Label>
           <Input placeholder="username or token" {...register('username')} />
         </div>
         <div className="space-y-1">
-          <label className="text-xs text-gray-500">Password</label>
+          <Label>Password</Label>
           <Input type="password" placeholder="password" {...register('password')} />
         </div>
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Lookup Host</label>
+        <Label>Lookup Host</Label>
         <Input placeholder="myrouter.duckdns.org" {...register('lookup_host')} />
       </div>
     </>

--- a/frontend/src/pages/network/ddns-status-panel.tsx
+++ b/frontend/src/pages/network/ddns-status-panel.tsx
@@ -21,7 +21,7 @@ export function DdnsStatusPanel({ status }: DdnsStatusPanelProps) {
           {status.running ? 'Running' : 'Stopped'}
         </span>
         {status.public_ip ? (
-          <span className="ml-2 text-gray-500">IP: {status.public_ip}</span>
+          <span className="ml-2 text-gray-500 dark:text-gray-400">IP: {status.public_ip}</span>
         ) : null}
         {status.last_update ? (
           <span className="ml-2 text-xs text-gray-400">Updated: {status.last_update}</span>

--- a/frontend/src/pages/network/ddns-status-panel.tsx
+++ b/frontend/src/pages/network/ddns-status-panel.tsx
@@ -12,7 +12,7 @@ export function DdnsStatusPanel({ status }: DdnsStatusPanelProps) {
       <span
         className={`inline-block h-2.5 w-2.5 rounded-full ${
           status.running
-            ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]'
+            ? 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.6)] dark:bg-emerald-400'
             : 'bg-gray-300 dark:bg-gray-600'
         }`}
       />

--- a/frontend/src/pages/network/dhcp-leases-card.tsx
+++ b/frontend/src/pages/network/dhcp-leases-card.tsx
@@ -10,7 +10,7 @@ export function DhcpLeasesCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DHCP Leases</CardTitle>
+        <CardTitle>DHCP Leases</CardTitle>
         <List className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/dhcp-leases-card.tsx
+++ b/frontend/src/pages/network/dhcp-leases-card.tsx
@@ -11,7 +11,7 @@ export function DhcpLeasesCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DHCP Leases</CardTitle>
-        <List className="h-4 w-4 text-gray-500" />
+        <List className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {dhcpLeasesLoading ? (
@@ -23,7 +23,7 @@ export function DhcpLeasesCard() {
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b text-left text-gray-500">
+                <tr className="border-b text-left text-gray-500 dark:text-gray-400">
                   <th className="pb-2 font-medium">Hostname</th>
                   <th className="pb-2 font-medium">IP Address</th>
                   <th className="pb-2 font-medium">MAC Address</th>
@@ -35,8 +35,8 @@ export function DhcpLeasesCard() {
                   <tr key={lease.mac} className="border-b last:border-0">
                     <td className="py-2 text-gray-900 dark:text-white">{lease.hostname || '—'}</td>
                     <td className="py-2 font-mono text-gray-900 dark:text-white">{lease.ip}</td>
-                    <td className="py-2 font-mono text-gray-500">{lease.mac}</td>
-                    <td className="py-2 text-gray-500">
+                    <td className="py-2 font-mono text-gray-500 dark:text-gray-400">{lease.mac}</td>
+                    <td className="py-2 text-gray-500 dark:text-gray-400">
                       {new Date(lease.expiry * 1000).toLocaleString()}
                     </td>
                   </tr>

--- a/frontend/src/pages/network/dhcp-pool-form-fields.tsx
+++ b/frontend/src/pages/network/dhcp-pool-form-fields.tsx
@@ -1,6 +1,7 @@
 import { Controller, type Control, type FieldErrors, type UseFormRegister } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -25,10 +26,10 @@ export function DhcpPoolFormFields({ register, control, errors }: DhcpPoolFormFi
     <>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1">
-          <label className="flex items-center gap-1 text-xs text-gray-500">
+          <Label className="flex items-center gap-1">
             Start Offset
             <InfoTooltip text="First IP offset assigned to clients. Offset 100 on 192.168.1.x means the first assigned address is 192.168.1.100." />
-          </label>
+          </Label>
           <Input
             type="number"
             min={2}
@@ -44,10 +45,10 @@ export function DhcpPoolFormFields({ register, control, errors }: DhcpPoolFormFi
           ) : null}
         </div>
         <div className="space-y-1">
-          <label className="flex items-center gap-1 text-xs text-gray-500">
+          <Label className="flex items-center gap-1">
             Pool Size
             <InfoTooltip text="Maximum number of clients that can receive an IP address. E.g., 50 means up to 50 devices can connect." />
-          </label>
+          </Label>
           <Input
             type="number"
             min={1}
@@ -64,10 +65,10 @@ export function DhcpPoolFormFields({ register, control, errors }: DhcpPoolFormFi
         </div>
       </div>
       <div className="space-y-1">
-        <label className="flex items-center gap-1 text-xs text-gray-500">
+        <Label className="flex items-center gap-1">
           Lease Time
           <InfoTooltip text="How long a DHCP lease is valid before renewal. Shorter times reclaim IPs faster; longer times reduce DHCP traffic." />
-        </label>
+        </Label>
         <Controller
           name="lease_time"
           control={control}

--- a/frontend/src/pages/network/dhcp-pool-settings-card.tsx
+++ b/frontend/src/pages/network/dhcp-pool-settings-card.tsx
@@ -50,7 +50,7 @@ export function DhcpPoolSettingsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DHCP Configuration</CardTitle>
+        <CardTitle>DHCP Configuration</CardTitle>
         <Settings className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/dhcp-pool-settings-card.tsx
+++ b/frontend/src/pages/network/dhcp-pool-settings-card.tsx
@@ -51,7 +51,7 @@ export function DhcpPoolSettingsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DHCP Configuration</CardTitle>
-        <Settings className="h-4 w-4 text-gray-500" />
+        <Settings className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {dhcpLoading ? (

--- a/frontend/src/pages/network/dhcp-reservation-add-form.tsx
+++ b/frontend/src/pages/network/dhcp-reservation-add-form.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormHandleSubmit, UseFormRegister } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { DhcpReservationFormValues } from '@/lib/schemas/network-forms';
 
 type DhcpReservationAddFormProps = {
@@ -25,7 +26,7 @@ export function DhcpReservationAddForm({
       noValidate
     >
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Name</label>
+        <Label>Name</Label>
         <Input
           placeholder="laptop"
           aria-invalid={errors.name ? 'true' : undefined}
@@ -39,7 +40,7 @@ export function DhcpReservationAddForm({
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">MAC Address</label>
+        <Label>MAC Address</Label>
         <Input
           placeholder="AA:BB:CC:DD:EE:FF"
           className="font-mono"
@@ -54,7 +55,7 @@ export function DhcpReservationAddForm({
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">IP Address</label>
+        <Label>IP Address</Label>
         <Input
           placeholder="192.168.8.50"
           className="font-mono"

--- a/frontend/src/pages/network/dhcp-reservation-add-form.tsx
+++ b/frontend/src/pages/network/dhcp-reservation-add-form.tsx
@@ -69,7 +69,7 @@ export function DhcpReservationAddForm({
           </p>
         ) : null}
       </div>
-      <Button type="submit" size="sm" disabled={addPending}>
+      <Button type="submit" disabled={addPending}>
         {addPending ? 'Adding…' : 'Add'}
       </Button>
     </form>

--- a/frontend/src/pages/network/dhcp-reservations-card.tsx
+++ b/frontend/src/pages/network/dhcp-reservations-card.tsx
@@ -49,7 +49,7 @@ export function DhcpReservationsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DHCP Reservations</CardTitle>
+        <CardTitle>DHCP Reservations</CardTitle>
         <HardDrive className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/dhcp-reservations-card.tsx
+++ b/frontend/src/pages/network/dhcp-reservations-card.tsx
@@ -50,7 +50,7 @@ export function DhcpReservationsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DHCP Reservations</CardTitle>
-        <HardDrive className="h-4 w-4 text-gray-500" />
+        <HardDrive className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {dhcpReservationsLoading ? (

--- a/frontend/src/pages/network/dhcp-reservations-table.tsx
+++ b/frontend/src/pages/network/dhcp-reservations-table.tsx
@@ -19,7 +19,7 @@ export function DhcpReservationsTable({
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b text-left text-gray-500">
+          <tr className="border-b text-left text-gray-500 dark:text-gray-400">
             <th className="pb-2 font-medium">Name</th>
             <th className="pb-2 font-medium">MAC Address</th>
             <th className="pb-2 font-medium">IP Address</th>
@@ -33,7 +33,7 @@ export function DhcpReservationsTable({
               className="border-b last:border-0"
             >
               <td className="py-2 text-gray-900 dark:text-white">{reservation.name}</td>
-              <td className="py-2 font-mono text-gray-500">{reservation.mac}</td>
+              <td className="py-2 font-mono text-gray-500 dark:text-gray-400">{reservation.mac}</td>
               <td className="py-2 font-mono text-gray-900 dark:text-white">{reservation.ip}</td>
               <td className="py-2 text-right">
                 <Button

--- a/frontend/src/pages/network/diagnostics-card.tsx
+++ b/frontend/src/pages/network/diagnostics-card.tsx
@@ -42,7 +42,7 @@ export function DiagnosticsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Network Diagnostics</CardTitle>
-        <Activity className="h-4 w-4 text-gray-500" />
+        <Activity className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onRun)} className="space-y-4" noValidate>

--- a/frontend/src/pages/network/diagnostics-card.tsx
+++ b/frontend/src/pages/network/diagnostics-card.tsx
@@ -40,7 +40,7 @@ export function DiagnosticsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Network Diagnostics</CardTitle>
+        <CardTitle>Network Diagnostics</CardTitle>
         <Activity className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/diagnostics-card.tsx
+++ b/frontend/src/pages/network/diagnostics-card.tsx
@@ -4,6 +4,7 @@ import { Activity } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { InlineError } from '@/components/ui/inline-error';
 import { useRunDiagnostics } from '@/hooks/use-network';
 import { diagnosticsFormSchema, type DiagnosticsFormValues } from '@/lib/schemas/network-forms';
 
@@ -100,9 +101,7 @@ export function DiagnosticsCard() {
             </pre>
           )}
           {runDiagnostics.isError && (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-              {runDiagnostics.error.message}
-            </div>
+            <InlineError>{runDiagnostics.error.message}</InlineError>
           )}
         </form>
       </CardContent>

--- a/frontend/src/pages/network/diagnostics-card.tsx
+++ b/frontend/src/pages/network/diagnostics-card.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { InlineError } from '@/components/ui/inline-error';
+import { cn } from '@/lib/cn';
 import { useRunDiagnostics } from '@/hooks/use-network';
 import { diagnosticsFormSchema, type DiagnosticsFormValues } from '@/lib/schemas/network-forms';
 
@@ -46,20 +47,27 @@ export function DiagnosticsCard() {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onRun)} className="space-y-4" noValidate>
-          <div className="flex w-fit gap-1 rounded-md border p-1">
+          <div
+            role="tablist"
+            aria-label="Diagnostics type"
+            className="flex w-fit flex-wrap gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1 dark:border-white/10 dark:bg-gray-900/40"
+          >
             {TABS.map((tab) => (
               <button
                 key={tab.value}
                 type="button"
+                role="tab"
+                aria-selected={activeTab === tab.value}
                 onClick={() => {
                   setValue('type', tab.value, { shouldValidate: false });
                   runDiagnostics.reset();
                 }}
-                className={`rounded px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                className={cn(
+                  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500',
                   activeTab === tab.value
-                    ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
-                }`}
+                    ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-white'
+                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white',
+                )}
               >
                 {tab.label}
               </button>
@@ -76,11 +84,7 @@ export function DiagnosticsCard() {
               aria-describedby={errors.target ? 'diag-target-err' : undefined}
               {...register('target')}
             />
-            <Button
-              type="submit"
-              disabled={!targetValue?.trim() || runDiagnostics.isPending}
-              size="sm"
-            >
+            <Button type="submit" disabled={!targetValue?.trim() || runDiagnostics.isPending}>
               {runDiagnostics.isPending ? 'Running…' : 'Run'}
             </Button>
           </div>

--- a/frontend/src/pages/network/dns-entries-card.tsx
+++ b/frontend/src/pages/network/dns-entries-card.tsx
@@ -114,7 +114,7 @@ export function DnsEntriesCard() {
                   </p>
                 ) : null}
               </div>
-              <Button type="submit" size="sm" disabled={addDNSEntry.isPending}>
+              <Button type="submit" disabled={addDNSEntry.isPending}>
                 {addDNSEntry.isPending ? 'Adding…' : 'Add'}
               </Button>
             </form>

--- a/frontend/src/pages/network/dns-entries-card.tsx
+++ b/frontend/src/pages/network/dns-entries-card.tsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Label } from '@/components/ui/label';
 import { useDNSEntries, useAddDNSEntry, useDeleteDNSEntry } from '@/hooks/use-network';
 import { dnsEntryFormSchema, type DnsEntryFormValues } from '@/lib/schemas/network-forms';
 
@@ -85,7 +86,7 @@ export function DnsEntriesCard() {
               noValidate
             >
               <div className="space-y-1">
-                <label className="text-xs text-gray-500">Hostname</label>
+                <Label>Hostname</Label>
                 <Input
                   placeholder="myserver"
                   aria-invalid={errors.name ? 'true' : undefined}
@@ -99,7 +100,7 @@ export function DnsEntriesCard() {
                 ) : null}
               </div>
               <div className="space-y-1">
-                <label className="text-xs text-gray-500">IP Address</label>
+                <Label>IP Address</Label>
                 <Input
                   placeholder="192.168.8.10"
                   className="font-mono"

--- a/frontend/src/pages/network/dns-entries-card.tsx
+++ b/frontend/src/pages/network/dns-entries-card.tsx
@@ -38,7 +38,7 @@ export function DnsEntriesCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Local DNS Entries</CardTitle>
-        <MapPin className="h-4 w-4 text-gray-500" />
+        <MapPin className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {dnsEntriesLoading ? (
@@ -52,7 +52,7 @@ export function DnsEntriesCard() {
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="border-b text-left text-gray-500">
+                    <tr className="border-b text-left text-gray-500 dark:text-gray-400">
                       <th className="pb-2 font-medium">Hostname</th>
                       <th className="pb-2 font-medium">IP Address</th>
                       <th className="w-16 pb-2 font-medium"></th>

--- a/frontend/src/pages/network/dns-entries-card.tsx
+++ b/frontend/src/pages/network/dns-entries-card.tsx
@@ -36,7 +36,7 @@ export function DnsEntriesCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Local DNS Entries</CardTitle>
+        <CardTitle>Local DNS Entries</CardTitle>
         <MapPin className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/doh-card.tsx
+++ b/frontend/src/pages/network/doh-card.tsx
@@ -12,7 +12,7 @@ export function DoHCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DNS over HTTPS/TLS</CardTitle>
+        <CardTitle>DNS over HTTPS/TLS</CardTitle>
         <Lock className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/doh-card.tsx
+++ b/frontend/src/pages/network/doh-card.tsx
@@ -13,7 +13,7 @@ export function DoHCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DNS over HTTPS/TLS</CardTitle>
-        <Lock className="h-4 w-4 text-gray-500" />
+        <Lock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -41,7 +41,7 @@ export function DoHCard() {
                 aria-label="Toggle DNS over HTTPS"
               />
             </div>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Encrypts DNS queries to prevent eavesdropping and tampering. Requires{' '}
               <code className="rounded bg-gray-100 px-1 dark:bg-gray-800">https-dns-proxy</code> to
               be installed.

--- a/frontend/src/pages/network/failover-card.tsx
+++ b/frontend/src/pages/network/failover-card.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { ArrowDown, ArrowUp, ArrowLeftRight } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { CardInset } from '@/components/ui/card-inset';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -186,7 +187,7 @@ export function FailoverCard() {
 
             <div className="space-y-3">
               {draft?.candidates.map((candidate, index) => (
-                <div key={candidate.interface_name} className="rounded-md border p-3">
+                <CardInset key={candidate.interface_name}>
                   <div className="flex items-start justify-between gap-3">
                     <div className="space-y-1">
                       <div className="font-medium">{candidate.label}</div>
@@ -251,7 +252,7 @@ export function FailoverCard() {
                       Move down
                     </Button>
                   </div>
-                </div>
+                </CardInset>
               ))}
             </div>
 
@@ -324,18 +325,12 @@ export function FailoverCard() {
 
             <div className="flex flex-wrap gap-2">
               <Button
-                size="sm"
                 onClick={handleSave}
                 disabled={setConfig.isPending || ((draft?.enabled ?? false) && enabledCount === 0)}
               >
                 {setConfig.isPending ? 'Saving…' : 'Save Failover Settings'}
               </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleCancel}
-                disabled={setConfig.isPending}
-              >
+              <Button variant="outline" onClick={handleCancel} disabled={setConfig.isPending}>
                 Cancel
               </Button>
             </div>

--- a/frontend/src/pages/network/failover-card.tsx
+++ b/frontend/src/pages/network/failover-card.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { EmptyState } from '@/components/ui/empty-state';
+import { Label } from '@/components/ui/label';
 import { useFailoverConfig, useSetFailoverConfig, useFailoverEvents } from '@/hooks/use-network';
 import type { FailoverCandidate, FailoverConfig } from '@shared/index';
 
@@ -256,9 +257,9 @@ export function FailoverCard() {
 
             <div className="grid gap-4 md:grid-cols-2">
               <div className="space-y-2 md:col-span-2">
-                <label htmlFor="failover-track-ips" className="text-sm font-medium">
+                <Label htmlFor="failover-track-ips" className="text-sm font-medium">
                   Health targets
-                </label>
+                </Label>
                 <Input
                   id="failover-track-ips"
                   value={draft?.health.track_ips.join(', ') ?? ''}
@@ -288,9 +289,9 @@ export function FailoverCard() {
                 ['up', 'Successes before recovery'],
               ].map(([field, label]) => (
                 <div key={field} className="space-y-2">
-                  <label htmlFor={field} className="text-sm font-medium">
+                  <Label htmlFor={field} className="text-sm font-medium">
                     {label}
-                  </label>
+                  </Label>
                   <Input
                     id={field}
                     inputMode="numeric"

--- a/frontend/src/pages/network/failover-card.tsx
+++ b/frontend/src/pages/network/failover-card.tsx
@@ -55,7 +55,7 @@ export function FailoverCard() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Connection Failover</CardTitle>
+          <CardTitle>Connection Failover</CardTitle>
         </CardHeader>
         <CardContent className="space-y-2">
           <Skeleton className="h-4 w-1/2" />
@@ -70,7 +70,7 @@ export function FailoverCard() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm font-medium">Connection Failover</CardTitle>
+          <CardTitle>Connection Failover</CardTitle>
         </CardHeader>
         <CardContent>
           <EmptyState
@@ -110,7 +110,7 @@ export function FailoverCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Connection Failover</CardTitle>
+        <CardTitle>Connection Failover</CardTitle>
         <ArrowLeftRight className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/firewall-card.tsx
+++ b/frontend/src/pages/network/firewall-card.tsx
@@ -18,7 +18,7 @@ export function FirewallCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Firewall</CardTitle>
+        <CardTitle>Firewall</CardTitle>
         <Shield className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-6">

--- a/frontend/src/pages/network/firewall-card.tsx
+++ b/frontend/src/pages/network/firewall-card.tsx
@@ -19,7 +19,7 @@ export function FirewallCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Firewall</CardTitle>
-        <Shield className="h-4 w-4 text-gray-500" />
+        <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-6">
         <FirewallZonesSection zones={zones} zonesLoading={zonesLoading} />

--- a/frontend/src/pages/network/firewall-port-forward-add-form-grid.tsx
+++ b/frontend/src/pages/network/firewall-port-forward-add-form-grid.tsx
@@ -101,7 +101,7 @@ export function FirewallPortForwardAddFormGrid({
           </p>
         ) : null}
       </div>
-      <Button type="submit" size="sm" className="self-end" disabled={isPending}>
+      <Button type="submit" className="self-end" disabled={isPending}>
         {isPending ? 'Adding…' : 'Add'}
       </Button>
     </div>

--- a/frontend/src/pages/network/firewall-port-forward-add-form-grid.tsx
+++ b/frontend/src/pages/network/firewall-port-forward-add-form-grid.tsx
@@ -1,6 +1,7 @@
 import { Controller, type Control, type FieldErrors, type UseFormRegister } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -26,7 +27,7 @@ export function FirewallPortForwardAddFormGrid({
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-[1fr_auto_1fr_1fr_1fr_auto]">
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Name</label>
+        <Label>Name</Label>
         <Input
           placeholder="my-rule"
           aria-invalid={errors.name ? 'true' : undefined}
@@ -40,7 +41,7 @@ export function FirewallPortForwardAddFormGrid({
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Protocol</label>
+        <Label>Protocol</Label>
         <Controller
           name="protocol"
           control={control}
@@ -59,7 +60,7 @@ export function FirewallPortForwardAddFormGrid({
         />
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">External Port</label>
+        <Label>External Port</Label>
         <Input
           placeholder="8080"
           aria-invalid={errors.src_dport ? 'true' : undefined}
@@ -73,7 +74,7 @@ export function FirewallPortForwardAddFormGrid({
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Internal IP</label>
+        <Label>Internal IP</Label>
         <Input
           placeholder="192.168.8.10"
           aria-invalid={errors.dest_ip ? 'true' : undefined}
@@ -87,7 +88,7 @@ export function FirewallPortForwardAddFormGrid({
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Internal Port</label>
+        <Label>Internal Port</Label>
         <Input
           placeholder="80"
           aria-invalid={errors.dest_port ? 'true' : undefined}

--- a/frontend/src/pages/network/firewall-port-forward-add-form.tsx
+++ b/frontend/src/pages/network/firewall-port-forward-add-form.tsx
@@ -55,7 +55,7 @@ export function FirewallPortForwardAddForm({ addRule }: FirewallPortForwardAddFo
       noValidate
       aria-label="Add port forwarding rule"
     >
-      <p className="text-xs text-gray-500">Add port forwarding rule</p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">Add port forwarding rule</p>
       <FirewallPortForwardAddFormGrid
         register={register}
         control={control}

--- a/frontend/src/pages/network/firewall-port-forward-rules-table.tsx
+++ b/frontend/src/pages/network/firewall-port-forward-rules-table.tsx
@@ -17,7 +17,7 @@ export function FirewallPortForwardRulesTable({
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b text-left text-gray-500">
+          <tr className="border-b text-left text-gray-500 dark:text-gray-400">
             <th className="pb-2 font-medium">Name</th>
             <th className="pb-2 font-medium">Protocol</th>
             <th className="pb-2 font-medium">Ext. Port</th>
@@ -30,7 +30,7 @@ export function FirewallPortForwardRulesTable({
           {rules.map((rule) => (
             <tr key={rule.id} className="border-b last:border-0">
               <td className="py-2 text-gray-900 dark:text-white">{rule.name}</td>
-              <td className="py-2 font-mono uppercase text-gray-500">{rule.protocol}</td>
+              <td className="py-2 font-mono uppercase text-gray-500 dark:text-gray-400">{rule.protocol}</td>
               <td className="py-2 font-mono text-gray-900 dark:text-white">{rule.src_dport}</td>
               <td className="py-2 font-mono text-gray-900 dark:text-white">{rule.dest_ip}</td>
               <td className="py-2 font-mono text-gray-900 dark:text-white">{rule.dest_port}</td>

--- a/frontend/src/pages/network/firewall-port-forward-section.tsx
+++ b/frontend/src/pages/network/firewall-port-forward-section.tsx
@@ -21,7 +21,7 @@ export function FirewallPortForwardSection({
 }: FirewallPortForwardSectionProps) {
   return (
     <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
         Port Forwarding
       </h3>
       {rulesLoading ? (

--- a/frontend/src/pages/network/firewall-zones-section.tsx
+++ b/frontend/src/pages/network/firewall-zones-section.tsx
@@ -12,7 +12,7 @@ type FirewallZonesSectionProps = {
 export function FirewallZonesSection({ zones, zonesLoading }: FirewallZonesSectionProps) {
   return (
     <div>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
         Firewall Zones
       </h3>
       {zonesLoading ? (
@@ -24,7 +24,7 @@ export function FirewallZonesSection({ zones, zonesLoading }: FirewallZonesSecti
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b text-left text-gray-500">
+              <tr className="border-b text-left text-gray-500 dark:text-gray-400">
                 <th className="pb-2 font-medium">Zone</th>
                 <th className="pb-2 font-medium">Networks</th>
                 <th className="pb-2 font-medium">Input</th>
@@ -37,7 +37,7 @@ export function FirewallZonesSection({ zones, zonesLoading }: FirewallZonesSecti
               {zones.map((zone) => (
                 <tr key={zone.name} className="border-b last:border-0">
                   <td className="py-2 font-medium text-gray-900 dark:text-white">{zone.name}</td>
-                  <td className="py-2 text-gray-500">
+                  <td className="py-2 text-gray-500 dark:text-gray-400">
                     {zone.network && zone.network.length > 0 ? zone.network.join(', ') : '—'}
                   </td>
                   <td className="py-2">

--- a/frontend/src/pages/network/interface-traffic-charts.tsx
+++ b/frontend/src/pages/network/interface-traffic-charts.tsx
@@ -23,7 +23,7 @@ export function InterfaceTrafficCharts() {
               connected ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-gray-400 dark:bg-gray-600'
             }`}
           />
-          <Activity className="h-4 w-4 text-gray-500" />
+          <Activity className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </div>
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/interface-traffic-charts.tsx
+++ b/frontend/src/pages/network/interface-traffic-charts.tsx
@@ -18,7 +18,11 @@ export function InterfaceTrafficCharts() {
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Interface Traffic</CardTitle>
         <div className="flex items-center gap-2">
-          <span className={`h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-400'}`} />
+          <span
+            className={`h-2 w-2 rounded-full ${
+              connected ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-gray-400 dark:bg-gray-600'
+            }`}
+          />
           <Activity className="h-4 w-4 text-gray-500" />
         </div>
       </CardHeader>

--- a/frontend/src/pages/network/interface-traffic-charts.tsx
+++ b/frontend/src/pages/network/interface-traffic-charts.tsx
@@ -16,7 +16,7 @@ export function InterfaceTrafficCharts() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Interface Traffic</CardTitle>
+        <CardTitle>Interface Traffic</CardTitle>
         <div className="flex items-center gap-2">
           <span className={`h-2 w-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-400'}`} />
           <Activity className="h-4 w-4 text-gray-500" />

--- a/frontend/src/pages/network/interfaces-card.tsx
+++ b/frontend/src/pages/network/interfaces-card.tsx
@@ -13,7 +13,7 @@ export function InterfacesCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Network Interfaces</CardTitle>
+        <CardTitle>Network Interfaces</CardTitle>
         <Power className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/interfaces-card.tsx
+++ b/frontend/src/pages/network/interfaces-card.tsx
@@ -14,7 +14,7 @@ export function InterfacesCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Network Interfaces</CardTitle>
-        <Power className="h-4 w-4 text-gray-500" />
+        <Power className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -38,7 +38,7 @@ export function InterfacesCard() {
                       {iface.name.toUpperCase()}
                     </span>
                     {iface.ip_address && (
-                      <span className="ml-2 text-xs text-gray-500">{iface.ip_address}</span>
+                      <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">{iface.ip_address}</span>
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/network/ipv6-card.tsx
+++ b/frontend/src/pages/network/ipv6-card.tsx
@@ -11,7 +11,7 @@ export function IPv6Card() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">IPv6</CardTitle>
+        <CardTitle>IPv6</CardTitle>
         <Globe className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/network/ipv6-card.tsx
+++ b/frontend/src/pages/network/ipv6-card.tsx
@@ -13,7 +13,7 @@ export function IPv6Card() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>IPv6</CardTitle>
-        <Globe className="h-4 w-4 text-gray-500" />
+        <Globe className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         {isLoading ? (
@@ -32,7 +32,7 @@ export function IPv6Card() {
               />
             </div>
             <div>
-              <p className="mb-1 text-xs font-medium text-gray-500">Global IPv6 Addresses</p>
+              <p className="mb-1 text-xs font-medium text-gray-500 dark:text-gray-400">Global IPv6 Addresses</p>
               {status?.addresses && status.addresses.length > 0 ? (
                 <ul className="space-y-1">
                   {status.addresses.map((addr) => (

--- a/frontend/src/pages/network/ipv6-card.tsx
+++ b/frontend/src/pages/network/ipv6-card.tsx
@@ -2,6 +2,7 @@ import { Globe } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useIPv6Status, useSetIPv6Enabled } from '@/hooks/use-network';
 
 export function IPv6Card() {
@@ -41,7 +42,7 @@ export function IPv6Card() {
                   ))}
                 </ul>
               ) : (
-                <p className="text-xs text-gray-500">No global IPv6 addresses</p>
+                <EmptyState message="No global IPv6 addresses" />
               )}
             </div>
           </>

--- a/frontend/src/pages/network/lan-config-card.tsx
+++ b/frontend/src/pages/network/lan-config-card.tsx
@@ -9,7 +9,7 @@ export function LanConfigCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">LAN Configuration</CardTitle>
+        <CardTitle>LAN Configuration</CardTitle>
         <Network className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/lan-config-card.tsx
+++ b/frontend/src/pages/network/lan-config-card.tsx
@@ -10,7 +10,7 @@ export function LanConfigCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>LAN Configuration</CardTitle>
-        <Network className="h-4 w-4 text-gray-500" />
+        <Network className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -21,11 +21,11 @@ export function LanConfigCard() {
         ) : network ? (
           <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
             <div className="grid grid-cols-2 gap-2">
-              <span className="text-gray-500">IP Address</span>
+              <span className="text-gray-500 dark:text-gray-400">IP Address</span>
               <span className="text-gray-900 dark:text-white">{network.lan.ip_address}</span>
-              <span className="text-gray-500">Subnet</span>
+              <span className="text-gray-500 dark:text-gray-400">Subnet</span>
               <span className="text-gray-900 dark:text-white">{network.lan.netmask}</span>
-              <span className="text-gray-500">MAC</span>
+              <span className="text-gray-500 dark:text-gray-400">MAC</span>
               <span className="text-gray-900 dark:text-white">{network.lan.mac_address}</span>
             </div>
           </div>

--- a/frontend/src/pages/network/lan-dns-server-fields.tsx
+++ b/frontend/src/pages/network/lan-dns-server-fields.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
+import { Label } from '@/components/ui/label';
 import type { DnsConfigFormValues } from '@/lib/schemas/network-forms';
 
 type LanDnsServerFieldsProps = {
@@ -12,10 +13,10 @@ export function LanDnsServerFields({ register, errors }: LanDnsServerFieldsProps
   return (
     <div className="grid grid-cols-2 gap-4">
       <div className="space-y-1">
-        <label className="flex items-center gap-1 text-xs text-gray-500">
+        <Label className="flex items-center gap-1">
           Primary DNS
           <InfoTooltip text="DNS server that resolves domain names to IP addresses for all LAN clients. E.g., 8.8.8.8 (Google), 1.1.1.1 (Cloudflare), 9.9.9.9 (Quad9)." />
-        </label>
+        </Label>
         <Input
           placeholder="8.8.8.8"
           aria-invalid={errors.server1 ? 'true' : undefined}
@@ -29,7 +30,7 @@ export function LanDnsServerFields({ register, errors }: LanDnsServerFieldsProps
         ) : null}
       </div>
       <div className="space-y-1">
-        <label className="text-xs text-gray-500">Secondary DNS</label>
+        <Label>Secondary DNS</Label>
         <Input placeholder="8.8.4.4" {...register('server2')} />
       </div>
     </div>

--- a/frontend/src/pages/network/lan-dns-settings-card.tsx
+++ b/frontend/src/pages/network/lan-dns-settings-card.tsx
@@ -52,7 +52,7 @@ export function LanDnsSettingsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DNS Configuration</CardTitle>
+        <CardTitle>DNS Configuration</CardTitle>
         <Globe className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/lan-dns-settings-card.tsx
+++ b/frontend/src/pages/network/lan-dns-settings-card.tsx
@@ -53,7 +53,7 @@ export function LanDnsSettingsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DNS Configuration</CardTitle>
-        <Globe className="h-4 w-4 text-gray-500" />
+        <Globe className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {dnsLoading ? (

--- a/frontend/src/pages/network/network-page-status-panel.tsx
+++ b/frontend/src/pages/network/network-page-status-panel.tsx
@@ -32,7 +32,7 @@ export function NetworkPageStatusPanel({
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Connected Clients</CardTitle>
-          <Network className="h-4 w-4 text-gray-500" />
+          <Network className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           {isLoading ? (

--- a/frontend/src/pages/network/network-page-status-panel.tsx
+++ b/frontend/src/pages/network/network-page-status-panel.tsx
@@ -31,7 +31,7 @@ export function NetworkPageStatusPanel({
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Connected Clients</CardTitle>
+          <CardTitle>Connected Clients</CardTitle>
           <Network className="h-4 w-4 text-gray-500" />
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/network/speed-test-card.tsx
+++ b/frontend/src/pages/network/speed-test-card.tsx
@@ -2,6 +2,7 @@ import { Gauge } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { InlineError } from '@/components/ui/inline-error';
 import { useRunSpeedTest } from '@/hooks/use-system';
 
 export function SpeedTestCard() {
@@ -47,11 +48,7 @@ export function SpeedTestCard() {
           </div>
         )}
 
-        {speedTest.isError && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-            {speedTest.error.message}
-          </div>
-        )}
+        {speedTest.isError && <InlineError>{speedTest.error.message}</InlineError>}
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/network/speed-test-card.tsx
+++ b/frontend/src/pages/network/speed-test-card.tsx
@@ -10,7 +10,7 @@ export function SpeedTestCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Speed Test</CardTitle>
+        <CardTitle>Speed Test</CardTitle>
         <Gauge className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/network/speed-test-card.tsx
+++ b/frontend/src/pages/network/speed-test-card.tsx
@@ -12,10 +12,10 @@ export function SpeedTestCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Speed Test</CardTitle>
-        <Gauge className="h-4 w-4 text-gray-500" />
+        <Gauge className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
           Measures download speed from the router using a 10 MB test file from Cloudflare.
         </p>
 
@@ -34,15 +34,15 @@ export function SpeedTestCard() {
         {speedTest.data && (
           <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
             <div className="grid grid-cols-2 gap-2">
-              <span className="text-gray-500">Download</span>
+              <span className="text-gray-500 dark:text-gray-400">Download</span>
               <span className="font-medium text-gray-900 dark:text-white">
                 {speedTest.data.download_mbps} Mbps
               </span>
-              <span className="text-gray-500">Latency</span>
+              <span className="text-gray-500 dark:text-gray-400">Latency</span>
               <span className="font-medium text-gray-900 dark:text-white">
                 {speedTest.data.ping_ms} ms
               </span>
-              <span className="text-gray-500">Server</span>
+              <span className="text-gray-500 dark:text-gray-400">Server</span>
               <span className="text-gray-900 dark:text-white">{speedTest.data.server}</span>
             </div>
           </div>

--- a/frontend/src/pages/network/uptime-log-card.tsx
+++ b/frontend/src/pages/network/uptime-log-card.tsx
@@ -9,7 +9,7 @@ export function UptimeLogCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Connection Uptime Log</CardTitle>
+        <CardTitle>Connection Uptime Log</CardTitle>
         <Cable className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/uptime-log-card.tsx
+++ b/frontend/src/pages/network/uptime-log-card.tsx
@@ -10,7 +10,7 @@ export function UptimeLogCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Connection Uptime Log</CardTitle>
-        <Cable className="h-4 w-4 text-gray-500" />
+        <Cable className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {!uptimeLog || uptimeLog.length === 0 ? (

--- a/frontend/src/pages/network/uptime-log-card.tsx
+++ b/frontend/src/pages/network/uptime-log-card.tsx
@@ -34,14 +34,22 @@ export function UptimeLogCard() {
                 <li key={event.timestamp} className="flex items-start gap-3 text-sm">
                   <span
                     className={`mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${
-                      isConnected ? 'bg-green-500' : 'bg-red-500'
+                      isConnected
+                        ? 'bg-emerald-500 dark:bg-emerald-400'
+                        : 'bg-red-500 dark:bg-red-400'
                     }`}
                   />
                   <div className="flex flex-col">
-                    <span className={isConnected ? 'text-green-700' : 'text-red-600'}>
+                    <span
+                      className={
+                        isConnected
+                          ? 'text-emerald-700 dark:text-emerald-400'
+                          : 'text-red-600 dark:text-red-400'
+                      }
+                    >
                       {isConnected ? 'Connected' : 'Disconnected'}
                     </span>
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
                       {new Date(event.timestamp).toLocaleString()}
                       {durationMs !== null && durationMs > 0 && (
                         <> &mdash; lasted {fmt(durationMs)}</>

--- a/frontend/src/pages/network/usb-tethering-section.tsx
+++ b/frontend/src/pages/network/usb-tethering-section.tsx
@@ -20,7 +20,7 @@ export function USBTetheringSection() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>USB Tethering</CardTitle>
-        <Smartphone className="h-4 w-4 text-gray-500" />
+        <Smartphone className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-3">
         {status?.detected ? (
@@ -49,7 +49,7 @@ export function USBTetheringSection() {
               )}
             </div>
             {status.ip_address && (
-              <p className="text-sm text-gray-500 font-mono">{status.ip_address}</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 font-mono">{status.ip_address}</p>
             )}
             {status.configured ? (
               <div className="flex items-center gap-2">
@@ -76,7 +76,7 @@ export function USBTetheringSection() {
             )}
           </div>
         ) : (
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
             <XCircle className="h-4 w-4" />
             <span>No USB tethering device detected (UCI config still active)</span>
             <Button

--- a/frontend/src/pages/network/usb-tethering-section.tsx
+++ b/frontend/src/pages/network/usb-tethering-section.tsx
@@ -19,7 +19,7 @@ export function USBTetheringSection() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">USB Tethering</CardTitle>
+        <CardTitle>USB Tethering</CardTitle>
         <Smartphone className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-3">

--- a/frontend/src/pages/network/usb-tethering-section.tsx
+++ b/frontend/src/pages/network/usb-tethering-section.tsx
@@ -39,13 +39,9 @@ export function USBTetheringSection() {
                 {status.interface}
               </Badge>
               {status.is_up ? (
-                <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 text-xs">
-                  Up
-                </Badge>
+                <Badge variant="success">Up</Badge>
               ) : (
-                <Badge variant="secondary" className="text-xs">
-                  Down
-                </Badge>
+                <Badge variant="secondary">Down</Badge>
               )}
             </div>
             {status.ip_address && (
@@ -53,9 +49,7 @@ export function USBTetheringSection() {
             )}
             {status.configured ? (
               <div className="flex items-center gap-2">
-                <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 text-xs">
-                  Configured as WAN
-                </Badge>
+                <Badge variant="default">Configured as WAN</Badge>
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/pages/network/wan-config-card.tsx
+++ b/frontend/src/pages/network/wan-config-card.tsx
@@ -3,6 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useNetworkStatus, useDetectWanType } from '@/hooks/use-network';
 import { formatBytes } from '@/lib/utils';
 
@@ -44,7 +45,7 @@ export function WanConfigCard() {
             </div>
           </div>
         ) : (
-          <p className="text-sm text-gray-500">WAN not configured</p>
+          <EmptyState message="WAN not configured" />
         )}
         <div className="mt-3 flex items-center gap-3">
           <Button

--- a/frontend/src/pages/network/wan-config-card.tsx
+++ b/frontend/src/pages/network/wan-config-card.tsx
@@ -13,7 +13,7 @@ export function WanConfigCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">WAN Configuration</CardTitle>
+        <CardTitle>WAN Configuration</CardTitle>
         <Wifi className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/network/wan-config-card.tsx
+++ b/frontend/src/pages/network/wan-config-card.tsx
@@ -15,7 +15,7 @@ export function WanConfigCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>WAN Configuration</CardTitle>
-        <Wifi className="h-4 w-4 text-gray-500" />
+        <Wifi className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -26,19 +26,19 @@ export function WanConfigCard() {
         ) : network?.wan ? (
           <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
             <div className="grid grid-cols-2 gap-2">
-              <span className="text-gray-500">Type</span>
+              <span className="text-gray-500 dark:text-gray-400">Type</span>
               <span className="text-gray-900 dark:text-white">{network.wan.type}</span>
-              <span className="text-gray-500">IP Address</span>
+              <span className="text-gray-500 dark:text-gray-400">IP Address</span>
               <span className="text-gray-900 dark:text-white">{network.wan.ip_address}</span>
-              <span className="text-gray-500">Gateway</span>
+              <span className="text-gray-500 dark:text-gray-400">Gateway</span>
               <span className="text-gray-900 dark:text-white">{network.wan.gateway}</span>
-              <span className="text-gray-500">DNS</span>
+              <span className="text-gray-500 dark:text-gray-400">DNS</span>
               <span className="text-gray-900 dark:text-white">
                 {(network.wan.dns_servers ?? []).join(', ') || '—'}
               </span>
-              <span className="text-gray-500">MAC</span>
+              <span className="text-gray-500 dark:text-gray-400">MAC</span>
               <span className="text-gray-900 dark:text-white">{network.wan.mac_address}</span>
-              <span className="text-gray-500">Traffic</span>
+              <span className="text-gray-500 dark:text-gray-400">Traffic</span>
               <span className="text-gray-900 dark:text-white">
                 ↓ {formatBytes(network.wan.rx_bytes)} / ↑ {formatBytes(network.wan.tx_bytes)}
               </span>

--- a/frontend/src/pages/network/wan-status-card.tsx
+++ b/frontend/src/pages/network/wan-status-card.tsx
@@ -50,7 +50,7 @@ function WanInterplay({ interfaces }: { interfaces: readonly NetworkInterface[] 
             <div className="flex-1">
               <span className="text-sm font-medium text-gray-900 dark:text-white">{src.label}</span>
               {src.iface && (
-                <span className="ml-2 text-xs text-gray-500">
+                <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
                   {src.active ? src.iface.ip_address : 'down'}
                 </span>
               )}
@@ -88,7 +88,7 @@ export function WanStatusCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>WAN Status</CardTitle>
-        <Cable className="h-4 w-4 text-gray-500" />
+        <Cable className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         {/* Internet connectivity row */}

--- a/frontend/src/pages/network/wan-status-card.tsx
+++ b/frontend/src/pages/network/wan-status-card.tsx
@@ -42,7 +42,7 @@ function WanInterplay({ interfaces }: { interfaces: readonly NetworkInterface[] 
             <span
               className={`inline-block h-2.5 w-2.5 rounded-full ${
                 src.active
-                  ? 'bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]'
+                  ? 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.6)] dark:bg-emerald-400'
                   : 'bg-gray-300 dark:bg-gray-600'
               }`}
               aria-label={src.active ? 'Active' : 'Inactive'}

--- a/frontend/src/pages/network/wan-status-card.tsx
+++ b/frontend/src/pages/network/wan-status-card.tsx
@@ -87,7 +87,7 @@ export function WanStatusCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">WAN Status</CardTitle>
+        <CardTitle>WAN Status</CardTitle>
         <Cable className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/network/wol-card.tsx
+++ b/frontend/src/pages/network/wol-card.tsx
@@ -32,7 +32,7 @@ export function WoLCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Wake-on-LAN</CardTitle>
-        <Zap className="h-4 w-4 text-gray-500" />
+        <Zap className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-3" noValidate>

--- a/frontend/src/pages/network/wol-card.tsx
+++ b/frontend/src/pages/network/wol-card.tsx
@@ -4,6 +4,7 @@ import { Zap } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { useSendWoL } from '@/hooks/use-network';
 import { wolFormSchema, type WolFormValues } from '@/lib/schemas/network-forms';
 
@@ -36,7 +37,7 @@ export function WoLCard() {
       <CardContent>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-3" noValidate>
           <div className="space-y-1">
-            <label className="text-xs text-gray-500">MAC Address</label>
+            <Label>MAC Address</Label>
             <Input
               className="font-mono"
               placeholder="AA:BB:CC:DD:EE:FF"
@@ -51,7 +52,7 @@ export function WoLCard() {
             ) : null}
           </div>
           <div className="space-y-1">
-            <label className="text-xs text-gray-500">Interface (optional)</label>
+            <Label>Interface (optional)</Label>
             <Input placeholder="br-lan" {...register('interface')} />
           </div>
           <Button type="submit" size="sm" disabled={sendWoL.isPending}>

--- a/frontend/src/pages/network/wol-card.tsx
+++ b/frontend/src/pages/network/wol-card.tsx
@@ -55,7 +55,7 @@ export function WoLCard() {
             <Label>Interface (optional)</Label>
             <Input placeholder="br-lan" {...register('interface')} />
           </div>
-          <Button type="submit" size="sm" disabled={sendWoL.isPending}>
+          <Button type="submit" disabled={sendWoL.isPending}>
             <Zap className="mr-1.5 h-3.5 w-3.5" />
             {sendWoL.isPending ? 'Sending…' : 'Send Magic Packet'}
           </Button>

--- a/frontend/src/pages/network/wol-card.tsx
+++ b/frontend/src/pages/network/wol-card.tsx
@@ -30,7 +30,7 @@ export function WoLCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Wake-on-LAN</CardTitle>
+        <CardTitle>Wake-on-LAN</CardTitle>
         <Zap className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/services/__tests__/speedtest-page.test.tsx
+++ b/frontend/src/pages/services/__tests__/speedtest-page.test.tsx
@@ -176,7 +176,53 @@ describe('SpeedtestPage', () => {
     renderSpeedtestPage();
 
     await waitFor(() => {
-      expect(screen.getByText(/Failed to load speedtest service/i)).toBeInTheDocument();
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(/Failed to load speedtest service/i);
+      expect(alert.className).toContain('border-red');
+    });
+  });
+
+  it('shows empty state when status is missing after load', async () => {
+    mockUseSpeedtestServiceStatus.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useSpeedtestServiceStatus>);
+
+    renderSpeedtestPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/No speedtest status available/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows run error via InlineError', async () => {
+    mockUseSpeedtestServiceStatus.mockReturnValue({
+      data: { ...mockStatus, installed: true },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof useSpeedtestServiceStatus>);
+
+    mockUseRunSpeedtest.mockReturnValue({
+      mutate: vi.fn(),
+      mutateAsync: vi.fn(),
+      isPending: false,
+      isError: true,
+      isSuccess: false,
+      isIdle: false,
+      reset: vi.fn(),
+      status: 'error',
+      voidFn: vi.fn(),
+      data: undefined,
+      error: new Error('Speed test failed'),
+    } as unknown as ReturnType<typeof useRunSpeedtest>);
+
+    renderSpeedtestPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Speed test failed');
     });
   });
 

--- a/frontend/src/pages/services/service-card.tsx
+++ b/frontend/src/pages/services/service-card.tsx
@@ -1,6 +1,6 @@
 import type { ServiceInfo } from '@shared/index';
 import { Globe } from 'lucide-react';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { useAdGuardDNS, useSetAdGuardDNS } from '@/hooks/use-services';
@@ -39,60 +39,61 @@ export function ServiceCard({
 
   return (
     <Card className="shadow-none hover:shadow-none">
-      <CardContent className="p-4">
-        <div className="flex items-start gap-3">
-          <div className="rounded-md bg-blue-50 p-2 dark:bg-blue-950">
-            <Icon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+      <CardHeader className="flex flex-row items-start gap-3 space-y-0 pb-2">
+        <div className="rounded-md bg-blue-50 p-2 dark:bg-blue-950">
+          <Icon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <CardTitle>{service.name}</CardTitle>
+            <Badge variant={serviceStateBadgeVariant[service.state]}>
+              {serviceStateLabels[service.state]}
+            </Badge>
           </div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <h3 className="font-medium text-gray-900 dark:text-white">{service.name}</h3>
-              <Badge variant={serviceStateBadgeVariant[service.state]}>
-                {serviceStateLabels[service.state]}
-              </Badge>
-            </div>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{service.description}</p>
-            {service.version && <p className="mt-0.5 text-xs text-gray-400">v{service.version}</p>}
-
-            {service.state !== 'not_installed' && (
-              <div className="mt-2">
-                <Switch
-                  id={`autostart-${service.id}`}
-                  label="Auto-start"
-                  checked={service.auto_start}
-                  disabled={isAutoStartPending}
-                  onChange={() => onAutoStartChange(service.id, !service.auto_start)}
-                />
-              </div>
-            )}
-
-            {isAdGuardRunning && dnsStatus && (
-              <div className="mt-2">
-                <Switch
-                  id="adguard-dns-toggle"
-                  label="DNS Filtering Active"
-                  checked={dnsStatus.enabled}
-                  disabled={setDNS.isPending}
-                  onChange={() => setDNS.mutate(!dnsStatus.enabled)}
-                />
-                <p className="mt-0.5 text-xs text-gray-400">
-                  {dnsStatus.enabled
-                    ? `Forwarding LAN DNS to AdGuard (port ${dnsStatus.dns_port})`
-                    : 'AdGuard is not handling LAN DNS queries'}
-                </p>
-              </div>
-            )}
-
-            <ServiceCardActionButtons
-              service={service}
-              isPending={isPending}
-              onInstall={onInstall}
-              onRemove={onRemove}
-              onStart={onStart}
-              onStop={onStop}
+          <p className="text-sm text-gray-500 dark:text-gray-400">{service.description}</p>
+          {service.version && (
+            <p className="text-xs text-gray-400 dark:text-gray-500">v{service.version}</p>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {service.state !== 'not_installed' && (
+          <div className="mt-2">
+            <Switch
+              id={`autostart-${service.id}`}
+              label="Auto-start"
+              checked={service.auto_start}
+              disabled={isAutoStartPending}
+              onChange={() => onAutoStartChange(service.id, !service.auto_start)}
             />
           </div>
-        </div>
+        )}
+
+        {isAdGuardRunning && dnsStatus && (
+          <div className="mt-2">
+            <Switch
+              id="adguard-dns-toggle"
+              label="DNS Filtering Active"
+              checked={dnsStatus.enabled}
+              disabled={setDNS.isPending}
+              onChange={() => setDNS.mutate(!dnsStatus.enabled)}
+            />
+            <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+              {dnsStatus.enabled
+                ? `Forwarding LAN DNS to AdGuard (port ${dnsStatus.dns_port})`
+                : 'AdGuard is not handling LAN DNS queries'}
+            </p>
+          </div>
+        )}
+
+        <ServiceCardActionButtons
+          service={service}
+          isPending={isPending}
+          onInstall={onInstall}
+          onRemove={onRemove}
+          onStart={onStart}
+          onStop={onStop}
+        />
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/services/service-card.tsx
+++ b/frontend/src/pages/services/service-card.tsx
@@ -51,7 +51,7 @@ export function ServiceCard({
                 {serviceStateLabels[service.state]}
               </Badge>
             </div>
-            <p className="mt-1 text-sm text-gray-500">{service.description}</p>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">{service.description}</p>
             {service.version && <p className="mt-0.5 text-xs text-gray-400">v{service.version}</p>}
 
             {service.state !== 'not_installed' && (

--- a/frontend/src/pages/services/service-card.tsx
+++ b/frontend/src/pages/services/service-card.tsx
@@ -38,7 +38,7 @@ export function ServiceCard({
   const setDNS = useSetAdGuardDNS();
 
   return (
-    <Card>
+    <Card className="shadow-none hover:shadow-none">
       <CardContent className="p-4">
         <div className="flex items-start gap-3">
           <div className="rounded-md bg-blue-50 p-2 dark:bg-blue-950">

--- a/frontend/src/pages/services/services-installed-card.tsx
+++ b/frontend/src/pages/services/services-installed-card.tsx
@@ -34,7 +34,7 @@ export function ServicesInstalledCard({
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Installed Services</CardTitle>
-        <Package className="h-4 w-4 text-gray-500" />
+        <Package className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {isLoading ? (

--- a/frontend/src/pages/services/services-installed-card.tsx
+++ b/frontend/src/pages/services/services-installed-card.tsx
@@ -33,7 +33,7 @@ export function ServicesInstalledCard({
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Installed Services</CardTitle>
+        <CardTitle>Installed Services</CardTitle>
         <Package className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/services/speedtest-page.tsx
+++ b/frontend/src/pages/services/speedtest-page.tsx
@@ -8,6 +8,8 @@ import {
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { InlineError } from '@/components/ui/inline-error';
+import { EmptyState } from '@/components/ui/empty-state';
 
 export function SpeedtestPage() {
   const { data: status, isLoading, error: statusError } = useSpeedtestServiceStatus();
@@ -29,15 +31,21 @@ export function SpeedtestPage() {
 
   if (statusError) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
-        <AlertTriangle className="mr-2 inline h-4 w-4" />
-        Failed to load speedtest service: {statusError.message}
+      <div className="space-y-6">
+        <InlineError>
+          <AlertTriangle className="mr-2 inline h-4 w-4" />
+          Failed to load speedtest service: {statusError.message}
+        </InlineError>
       </div>
     );
   }
 
   if (!status) {
-    return null;
+    return (
+      <div className="space-y-6">
+        <EmptyState message="No speedtest status available." />
+      </div>
+    );
   }
 
   return (
@@ -155,9 +163,7 @@ export function SpeedtestPage() {
           )}
 
           {runMutation.isError && (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
-              {runMutation.error?.message || 'Speed test failed'}
-            </div>
+            <InlineError>{runMutation.error?.message || 'Speed test failed'}</InlineError>
           )}
         </CardContent>
       </Card>

--- a/frontend/src/pages/services/speedtest-page.tsx
+++ b/frontend/src/pages/services/speedtest-page.tsx
@@ -53,7 +53,7 @@ export function SpeedtestPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>speedtest CLI</CardTitle>
-          <Gauge className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+          <Gauge className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-4 rounded-md bg-gray-50 p-4 text-sm dark:bg-gray-900 md:grid-cols-2">
@@ -116,7 +116,7 @@ export function SpeedtestPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Run Speed Test</CardTitle>
-          <Gauge className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+          <Gauge className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent className="space-y-4">
           <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/pages/services/speedtest-page.tsx
+++ b/frontend/src/pages/services/speedtest-page.tsx
@@ -53,7 +53,7 @@ export function SpeedtestPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>speedtest CLI</CardTitle>
-          <Gauge className="h-5 w-5 text-gray-500" />
+          <Gauge className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="grid gap-4 rounded-md bg-gray-50 p-4 text-sm dark:bg-gray-900 md:grid-cols-2">
@@ -116,7 +116,7 @@ export function SpeedtestPage() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Run Speed Test</CardTitle>
-          <Gauge className="h-5 w-5 text-gray-500" />
+          <Gauge className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent className="space-y-4">
           <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -134,28 +134,28 @@ export function SpeedtestPage() {
           {runMutation.data && (
             <div className="grid gap-3 rounded-md bg-gray-50 p-4 text-sm dark:bg-gray-900 md:grid-cols-2">
               <div className="flex items-center gap-2">
-                <Download className="h-4 w-4 text-gray-500" />
+                <Download className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <span className="text-gray-500 dark:text-gray-400">Download</span>
                 <span className="ml-auto font-medium">
                   {runMutation.data.download_mbps.toFixed(2)} Mbps
                 </span>
               </div>
               <div className="flex items-center gap-2">
-                <Upload className="h-4 w-4 text-gray-500" />
+                <Upload className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <span className="text-gray-500 dark:text-gray-400">Upload</span>
                 <span className="ml-auto font-medium">
                   {runMutation.data.upload_mbps.toFixed(2)} Mbps
                 </span>
               </div>
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-gray-500" />
+                <Clock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <span className="text-gray-500 dark:text-gray-400">Ping</span>
                 <span className="ml-auto font-medium">
                   {runMutation.data.ping_ms.toFixed(1)} ms
                 </span>
               </div>
               <div className="flex items-center gap-2">
-                <Server className="h-4 w-4 text-gray-500" />
+                <Server className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <span className="text-gray-500 dark:text-gray-400">Server</span>
                 <span className="ml-auto font-medium">{runMutation.data.server}</span>
               </div>

--- a/frontend/src/pages/services/speedtest-page.tsx
+++ b/frontend/src/pages/services/speedtest-page.tsx
@@ -44,7 +44,7 @@ export function SpeedtestPage() {
     <div className="space-y-6">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-base font-medium">speedtest CLI</CardTitle>
+          <CardTitle>speedtest CLI</CardTitle>
           <Gauge className="h-5 w-5 text-gray-500" />
         </CardHeader>
         <CardContent className="space-y-4">
@@ -107,7 +107,7 @@ export function SpeedtestPage() {
 
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-base font-medium">Run Speed Test</CardTitle>
+          <CardTitle>Run Speed Test</CardTitle>
           <Gauge className="h-5 w-5 text-gray-500" />
         </CardHeader>
         <CardContent className="space-y-4">

--- a/frontend/src/pages/services/sqm-page.tsx
+++ b/frontend/src/pages/services/sqm-page.tsx
@@ -23,7 +23,7 @@ export function SQMPage() {
       <div className="space-y-6">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">SQM (Traffic Shaping)</CardTitle>
+            <CardTitle>SQM (Traffic Shaping)</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <p className="text-sm">

--- a/frontend/src/pages/services/sqm-page.tsx
+++ b/frontend/src/pages/services/sqm-page.tsx
@@ -11,7 +11,7 @@ export function SQMPage() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-6">
         <Skeleton className="h-8 w-64" />
         <Skeleton className="h-64 w-full" />
       </div>
@@ -20,21 +20,27 @@ export function SQMPage() {
 
   if (!sqm || sqm.state === 'not_installed') {
     return (
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">SQM (Traffic Shaping)</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <p className="text-sm">
-            Install SQM from Installed services, then configure shaping and latency settings here.
-          </p>
-          <Button asChild variant="secondary">
-            <Link to="/services">Go to Installed services</Link>
-          </Button>
-        </CardContent>
-      </Card>
+      <div className="space-y-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">SQM (Traffic Shaping)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <p className="text-sm">
+              Install SQM from Installed services, then configure shaping and latency settings here.
+            </p>
+            <Button asChild variant="secondary">
+              <Link to="/services">Go to Installed services</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
     );
   }
 
-  return <SQMSection sqmService={sqm} />;
+  return (
+    <div className="space-y-6">
+      <SQMSection sqmService={sqm} />
+    </div>
+  );
 }

--- a/frontend/src/pages/services/sqm-section.tsx
+++ b/frontend/src/pages/services/sqm-section.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { InlineError } from '@/components/ui/inline-error';
+import { Label } from '@/components/ui/label';
 import type { ServiceInfo, SQMConfig, SQMQdisc, SQMScript } from '@shared/index';
 import { useApplySQM, useSQMConfig, useSetSQMConfig } from '@/hooks/use-sqm';
 
@@ -66,9 +67,9 @@ export function SQMSection({ sqmService }: Props) {
 
         <div className="flex items-center justify-between gap-3">
           <div className="space-y-1">
-            <label htmlFor="sqm-enabled" className="text-sm font-medium leading-none">
+            <Label htmlFor="sqm-enabled" className="text-sm font-medium leading-none">
               Enable SQM
-            </label>
+            </Label>
           </div>
           <Switch
             id="sqm-enabled"
@@ -82,9 +83,9 @@ export function SQMSection({ sqmService }: Props) {
 
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
-            <label htmlFor="sqm-interface" className="text-sm font-medium leading-none">
+            <Label htmlFor="sqm-interface" className="text-sm font-medium leading-none">
               Interface
-            </label>
+            </Label>
             <Input
               id="sqm-interface"
               placeholder="pppoe-wan / eth0.2 / wan"
@@ -141,9 +142,9 @@ export function SQMSection({ sqmService }: Props) {
 
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
-            <label htmlFor="sqm-download" className="text-sm font-medium leading-none">
+            <Label htmlFor="sqm-download" className="text-sm font-medium leading-none">
               Download (kbit/s)
-            </label>
+            </Label>
             <Input
               id="sqm-download"
               inputMode="numeric"
@@ -155,9 +156,9 @@ export function SQMSection({ sqmService }: Props) {
             />
           </div>
           <div className="space-y-2">
-            <label htmlFor="sqm-upload" className="text-sm font-medium leading-none">
+            <Label htmlFor="sqm-upload" className="text-sm font-medium leading-none">
               Upload (kbit/s)
-            </label>
+            </Label>
             <Input
               id="sqm-upload"
               inputMode="numeric"

--- a/frontend/src/pages/services/sqm-section.tsx
+++ b/frontend/src/pages/services/sqm-section.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { InlineError } from '@/components/ui/inline-error';
 import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
 import type { ServiceInfo, SQMConfig, SQMQdisc, SQMScript } from '@shared/index';
 import { useApplySQM, useSQMConfig, useSetSQMConfig } from '@/hooks/use-sqm';
 
@@ -59,7 +60,13 @@ export function SQMSection({ sqmService }: Props) {
       </CardHeader>
       <CardContent className="space-y-4">
         {data?.advanced_hint ? <p className="text-sm">{data.advanced_hint}</p> : null}
-        {isLoading ? <p className="text-sm">Loading SQM configuration…</p> : null}
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ) : null}
         {isError ? <InlineError>Failed to load SQM configuration.</InlineError> : null}
         {hasUnsavedChanges ? (
           <p className="text-sm">You have unsaved changes. Save before applying.</p>

--- a/frontend/src/pages/services/sqm-section.tsx
+++ b/frontend/src/pages/services/sqm-section.tsx
@@ -53,7 +53,7 @@ export function SQMSection({ sqmService }: Props) {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">SQM (Traffic Shaping)</CardTitle>
+        <CardTitle>SQM (Traffic Shaping)</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         {data?.advanced_hint ? <p className="text-sm">{data.advanced_hint}</p> : null}

--- a/frontend/src/pages/services/sqm-section.tsx
+++ b/frontend/src/pages/services/sqm-section.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { InlineError } from '@/components/ui/inline-error';
 import type { ServiceInfo, SQMConfig, SQMQdisc, SQMScript } from '@shared/index';
 import { useApplySQM, useSQMConfig, useSetSQMConfig } from '@/hooks/use-sqm';
 
@@ -58,7 +59,7 @@ export function SQMSection({ sqmService }: Props) {
       <CardContent className="space-y-4">
         {data?.advanced_hint ? <p className="text-sm">{data.advanced_hint}</p> : null}
         {isLoading ? <p className="text-sm">Loading SQM configuration…</p> : null}
-        {isError ? <p className="text-sm">Failed to load SQM configuration.</p> : null}
+        {isError ? <InlineError>Failed to load SQM configuration.</InlineError> : null}
         {hasUnsavedChanges ? (
           <p className="text-sm">You have unsaved changes. Save before applying.</p>
         ) : null}

--- a/frontend/src/pages/services/tailscale-auth-section.tsx
+++ b/frontend/src/pages/services/tailscale-auth-section.tsx
@@ -30,7 +30,7 @@ export function TailscaleAuthSection() {
           aria-label="Tailscale pre-auth key"
           {...register('auth_key')}
         />
-        <Button type="submit" size="sm" disabled={authMutation.isPending}>
+        <Button type="submit" disabled={authMutation.isPending}>
           Authenticate
         </Button>
       </form>

--- a/frontend/src/pages/services/tailscale-logged-in-panel.tsx
+++ b/frontend/src/pages/services/tailscale-logged-in-panel.tsx
@@ -43,9 +43,7 @@ export function TailscaleLoggedInPanel({
               {status.exit_node}
             </span>
             {status.exit_node_active && (
-              <Badge className="bg-green-100 text-xs text-green-800 dark:bg-green-900 dark:text-green-200">
-                Active
-              </Badge>
+              <Badge variant="success">Active</Badge>
             )}
             <Button
               variant="ghost"

--- a/frontend/src/pages/services/tailscale-logged-in-panel.tsx
+++ b/frontend/src/pages/services/tailscale-logged-in-panel.tsx
@@ -30,15 +30,15 @@ export function TailscaleLoggedInPanel({
     <>
       <div className="space-y-1 rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
         <div className="grid grid-cols-2 gap-x-4 gap-y-1">
-          <span className="text-gray-500">IP Address</span>
+          <span className="text-gray-500 dark:text-gray-400">IP Address</span>
           <span className="font-mono text-gray-900 dark:text-white">{status.ip_address}</span>
-          <span className="text-gray-500">Hostname</span>
+          <span className="text-gray-500 dark:text-gray-400">Hostname</span>
           <span className="text-gray-900 dark:text-white">{status.hostname}</span>
         </div>
         {status.exit_node && (
           <div className="mt-2 flex items-center gap-2 border-t border-gray-200 pt-2 dark:border-gray-700">
             <Wifi className="h-3 w-3 text-blue-500" />
-            <span className="text-xs text-gray-500">Exit node:</span>
+            <span className="text-xs text-gray-500 dark:text-gray-400">Exit node:</span>
             <span className="font-mono text-xs text-gray-900 dark:text-white">
               {status.exit_node}
             </span>
@@ -50,7 +50,7 @@ export function TailscaleLoggedInPanel({
             <Button
               variant="ghost"
               size="sm"
-              className="h-5 px-1 text-xs text-gray-500"
+              className="h-5 px-1 text-xs text-gray-500 dark:text-gray-400"
               onClick={onClearExitNode}
               disabled={exitNodePending}
             >
@@ -64,7 +64,7 @@ export function TailscaleLoggedInPanel({
         <div className="flex items-center justify-between border-t border-gray-100 py-1 dark:border-white/[0.08]">
           <div>
             <span className="text-sm text-gray-700 dark:text-gray-300">Allow Tailscale SSH</span>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Let Tailscale manage SSH access from trusted devices
             </p>
           </div>
@@ -86,7 +86,7 @@ export function TailscaleLoggedInPanel({
               one full-tunnel VPN path runs at a time.
             </p>
           )}
-          <div className="mb-1 flex items-center gap-1 text-xs text-gray-500">
+          <div className="mb-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
             <Users className="h-3 w-3" />
             <span>
               {status.peers.length} peer{status.peers.length !== 1 ? 's' : ''}

--- a/frontend/src/pages/services/tailscale-peer-row.tsx
+++ b/frontend/src/pages/services/tailscale-peer-row.tsx
@@ -19,7 +19,7 @@ export function TailscalePeerRow({ peer, onSetExitNode, isPending }: TailscalePe
         />
         <div className="min-w-0">
           <span className="truncate text-sm font-medium">{peer.hostname}</span>
-          <span className="ml-2 font-mono text-xs text-gray-500">{peer.tailscale_ip}</span>
+          <span className="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">{peer.tailscale_ip}</span>
         </div>
         {peer.exit_node && (
           <Badge className="shrink-0 bg-blue-100 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">

--- a/frontend/src/pages/services/tailscale-peer-row.tsx
+++ b/frontend/src/pages/services/tailscale-peer-row.tsx
@@ -22,7 +22,7 @@ export function TailscalePeerRow({ peer, onSetExitNode, isPending }: TailscalePe
           <span className="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">{peer.tailscale_ip}</span>
         </div>
         {peer.exit_node && (
-          <Badge className="shrink-0 bg-blue-100 text-xs text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+          <Badge variant="default" className="shrink-0">
             Exit Node
           </Badge>
         )}

--- a/frontend/src/pages/services/tailscale-peer-row.tsx
+++ b/frontend/src/pages/services/tailscale-peer-row.tsx
@@ -13,7 +13,9 @@ export function TailscalePeerRow({ peer, onSetExitNode, isPending }: TailscalePe
     <div className="flex items-center justify-between py-1.5">
       <div className="flex min-w-0 items-center gap-2">
         <span
-          className={`h-2 w-2 shrink-0 rounded-full ${peer.online ? 'bg-green-500' : 'bg-gray-300'}`}
+          className={`h-2 w-2 shrink-0 rounded-full ${
+            peer.online ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-gray-300 dark:bg-gray-600'
+          }`}
         />
         <div className="min-w-0">
           <span className="truncate text-sm font-medium">{peer.hostname}</span>

--- a/frontend/src/pages/services/tailscale-section.tsx
+++ b/frontend/src/pages/services/tailscale-section.tsx
@@ -46,7 +46,7 @@ export function TailscaleSection() {
       />
       <Card className={!isInstalled ? 'opacity-60' : undefined}>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Tailscale</CardTitle>
+          <CardTitle>Tailscale</CardTitle>
           <Globe className="h-4 w-4 text-blue-500" />
         </CardHeader>
         <CardContent className="space-y-4">

--- a/frontend/src/pages/services/tailscale-section.tsx
+++ b/frontend/src/pages/services/tailscale-section.tsx
@@ -52,7 +52,7 @@ export function TailscaleSection() {
         <CardContent className="space-y-4">
           {!isInstalled ? (
             <div className="py-4 text-center">
-              <p className="mb-2 text-sm text-gray-500">Tailscale is not installed</p>
+              <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">Tailscale is not installed</p>
               <Link
                 to="/services"
                 className="text-sm text-blue-600 hover:underline dark:text-blue-400"

--- a/frontend/src/pages/setup/ap-step-credentials-fields.tsx
+++ b/frontend/src/pages/setup/ap-step-credentials-fields.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Eye, EyeOff } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { SetupApFormValues } from '@/pages/setup/setup-schema';
 
 type APStepCredentialsFieldsProps = {
@@ -19,12 +20,12 @@ export function APStepCredentialsFields({
   return (
     <>
       <div>
-        <label
+        <Label
           htmlFor="setup-ap-ssid"
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           Network Name (SSID)
-        </label>
+        </Label>
         <Input
           id="setup-ap-ssid"
           aria-invalid={!!errors.ssid}
@@ -39,12 +40,12 @@ export function APStepCredentialsFields({
         ) : null}
       </div>
       <div>
-        <label
+        <Label
           htmlFor="setup-ap-key"
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           Password
-        </label>
+        </Label>
         <div className="relative">
           <Input
             id="setup-ap-key"

--- a/frontend/src/pages/setup/password-step-form-fields.tsx
+++ b/frontend/src/pages/setup/password-step-form-fields.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Eye, EyeOff } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { SetupPasswordFormValues } from '@/pages/setup/setup-schema';
 
 type PasswordStepFormFieldsProps = {
@@ -19,12 +20,12 @@ export function PasswordStepFormFields({
   return (
     <>
       <div>
-        <label
+        <Label
           htmlFor="setup-current-password"
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           Current Password
-        </label>
+        </Label>
         <Input
           id="setup-current-password"
           type={showPassword ? 'text' : 'password'}
@@ -41,12 +42,12 @@ export function PasswordStepFormFields({
         ) : null}
       </div>
       <div>
-        <label
+        <Label
           htmlFor="setup-new-password"
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           New Password
-        </label>
+        </Label>
         <div className="relative">
           <Input
             id="setup-new-password"
@@ -73,12 +74,12 @@ export function PasswordStepFormFields({
         ) : null}
       </div>
       <div>
-        <label
+        <Label
           htmlFor="setup-confirm-password"
           className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           Confirm New Password
-        </label>
+        </Label>
         <Input
           id="setup-confirm-password"
           type={showPassword ? 'text' : 'password'}

--- a/frontend/src/pages/setup/setup-page.tsx
+++ b/frontend/src/pages/setup/setup-page.tsx
@@ -33,7 +33,7 @@ export function SetupPage() {
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-white to-blue-100 p-4 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
       <Card className="w-full max-w-lg shadow-lg">
         <CardHeader className="pb-2">
-          <CardTitle className="text-center text-sm font-medium text-gray-500">
+          <CardTitle className="text-center text-gray-500">
             Initial Setup
           </CardTitle>
         </CardHeader>

--- a/frontend/src/pages/setup/setup-page.tsx
+++ b/frontend/src/pages/setup/setup-page.tsx
@@ -33,7 +33,7 @@ export function SetupPage() {
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-white to-blue-100 p-4 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
       <Card className="w-full max-w-lg shadow-lg">
         <CardHeader className="pb-2">
-          <CardTitle className="text-center text-gray-500">
+          <CardTitle className="text-center text-gray-500 dark:text-gray-400">
             Initial Setup
           </CardTitle>
         </CardHeader>

--- a/frontend/src/pages/setup/setup-wifi-network-list.tsx
+++ b/frontend/src/pages/setup/setup-wifi-network-list.tsx
@@ -59,7 +59,7 @@ export function SetupWifiNetworkList({
                   onClick={() => onPickNetwork(network)}
                 >
                   <div className="flex items-center gap-3">
-                    <Signal className="h-4 w-4 text-gray-500" />
+                    <Signal className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                     <div>
                       <span className="text-sm font-medium text-gray-900 dark:text-white">
                         {network.ssid}

--- a/frontend/src/pages/setup/setup-wifi-network-list.tsx
+++ b/frontend/src/pages/setup/setup-wifi-network-list.tsx
@@ -3,6 +3,7 @@ import type { WifiScanResult } from '@shared/index';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { setupWifiSignalTier } from './setup-wifi-step-utils';
 
 type SetupWifiNetworkListProps = {
@@ -77,7 +78,7 @@ export function SetupWifiNetworkList({
               );
             })
         ) : (
-          <p className="p-4 text-center text-sm text-gray-400">No networks found. Try scanning.</p>
+          <EmptyState message="No networks found. Try scanning." />
         )}
       </div>
     </>

--- a/frontend/src/pages/setup/welcome-step.tsx
+++ b/frontend/src/pages/setup/welcome-step.tsx
@@ -20,15 +20,15 @@ export function WelcomeStep({ onNext }: { onNext: () => void }) {
       <div className="grid grid-cols-3 gap-4 pt-4">
         <div className="rounded-lg border p-3 dark:border-gray-700">
           <KeyRound className="mx-auto h-6 w-6 text-blue-500" />
-          <p className="mt-2 text-xs text-gray-500">Secure Password</p>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">Secure Password</p>
         </div>
         <div className="rounded-lg border p-3 dark:border-gray-700">
           <Wifi className="mx-auto h-6 w-6 text-blue-500" />
-          <p className="mt-2 text-xs text-gray-500">WiFi Connection</p>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">WiFi Connection</p>
         </div>
         <div className="rounded-lg border p-3 dark:border-gray-700">
           <Shield className="mx-auto h-6 w-6 text-blue-500" />
-          <p className="mt-2 text-xs text-gray-500">AP Configuration</p>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">AP Configuration</p>
         </div>
       </div>
       <Button onClick={onNext} size="lg" className="mt-4 w-full">

--- a/frontend/src/pages/setup/wifi-step-password-field.tsx
+++ b/frontend/src/pages/setup/wifi-step-password-field.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Eye, EyeOff } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { SetupWifiFormValues } from '@/pages/setup/setup-schema';
 
 type WifiStepPasswordFieldProps = {
@@ -20,12 +21,12 @@ export function WifiStepPasswordField({
 }: WifiStepPasswordFieldProps) {
   return (
     <div>
-      <label
+      <Label
         htmlFor="setup-wifi-psk"
         className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
         Password for &quot;{selectedSsid}&quot;
-      </label>
+      </Label>
       <div className="relative">
         <Input
           id="setup-wifi-psk"

--- a/frontend/src/pages/system/adguard-password-card.tsx
+++ b/frontend/src/pages/system/adguard-password-card.tsx
@@ -46,7 +46,7 @@ export function AdGuardPasswordCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">AdGuard Password</CardTitle>
+        <CardTitle>AdGuard Password</CardTitle>
         <KeyRound className="h-4 w-4 text-gray-500" />
       </CardHeader>
 

--- a/frontend/src/pages/system/adguard-password-card.tsx
+++ b/frontend/src/pages/system/adguard-password-card.tsx
@@ -91,12 +91,11 @@ export function AdGuardPasswordCard() {
             <div className="flex flex-wrap items-center gap-2">
               <Button
                 type="submit"
-                size="sm"
                 disabled={changePasswordMutation.isPending || isSubmitting}
               >
                 {changePasswordMutation.isPending ? 'Saving…' : 'Save Password'}
               </Button>
-              <Button type="button" size="sm" variant="outline" onClick={resetAndClose}>
+              <Button type="button" variant="outline" onClick={resetAndClose}>
                 Cancel
               </Button>
             </div>

--- a/frontend/src/pages/system/adguard-password-card.tsx
+++ b/frontend/src/pages/system/adguard-password-card.tsx
@@ -47,7 +47,7 @@ export function AdGuardPasswordCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>AdGuard Password</CardTitle>
-        <KeyRound className="h-4 w-4 text-gray-500" />
+        <KeyRound className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
 
       <CardContent>

--- a/frontend/src/pages/system/alert-thresholds-card.tsx
+++ b/frontend/src/pages/system/alert-thresholds-card.tsx
@@ -55,11 +55,9 @@ export function AlertThresholdsCard() {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Bell className="h-5 w-5" />
-          Alert Thresholds
-        </CardTitle>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle>Alert Thresholds</CardTitle>
+        <Bell className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-5">
         {isLoading ? (

--- a/frontend/src/pages/system/change-password-card.tsx
+++ b/frontend/src/pages/system/change-password-card.tsx
@@ -55,7 +55,7 @@ export function ChangePasswordCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Change Password</CardTitle>
-        <KeyRound className="h-4 w-4 text-gray-500" />
+        <KeyRound className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
 
       <CardContent>

--- a/frontend/src/pages/system/change-password-card.tsx
+++ b/frontend/src/pages/system/change-password-card.tsx
@@ -54,7 +54,7 @@ export function ChangePasswordCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Change Password</CardTitle>
+        <CardTitle>Change Password</CardTitle>
         <KeyRound className="h-4 w-4 text-gray-500" />
       </CardHeader>
 

--- a/frontend/src/pages/system/firmware-upgrade-card.tsx
+++ b/frontend/src/pages/system/firmware-upgrade-card.tsx
@@ -63,7 +63,7 @@ export function FirmwareUpgradeCard() {
     <>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Firmware Upgrade</CardTitle>
+          <CardTitle>Firmware Upgrade</CardTitle>
           <Zap className="h-4 w-4 text-gray-500" />
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/system/firmware-upgrade-card.tsx
+++ b/frontend/src/pages/system/firmware-upgrade-card.tsx
@@ -64,7 +64,7 @@ export function FirmwareUpgradeCard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Firmware Upgrade</CardTitle>
-          <Zap className="h-4 w-4 text-gray-500" />
+          <Zap className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <FirmwareUpgradeFormFields

--- a/frontend/src/pages/system/firmware-upgrade-form-fields.tsx
+++ b/frontend/src/pages/system/firmware-upgrade-form-fields.tsx
@@ -32,7 +32,7 @@ export function FirmwareUpgradeFormFields({
 }: FirmwareUpgradeFormFieldsProps) {
   return (
     <div className="space-y-3">
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-gray-500 dark:text-gray-400">
         Upload a sysupgrade firmware image (.bin) to flash the device.
       </p>
       <div>

--- a/frontend/src/pages/system/firmware-upgrade-form-fields.tsx
+++ b/frontend/src/pages/system/firmware-upgrade-form-fields.tsx
@@ -3,6 +3,7 @@ import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Zap, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import { formatBytes } from '@/lib/utils';
 import type { FirmwareUpgradeFormValues } from '@/lib/schemas/system-forms';
 
@@ -58,9 +59,9 @@ export function FirmwareUpgradeFormFields({
         ) : null}
       </div>
       <div className="flex items-center justify-between">
-        <label htmlFor="keep-settings" className="text-sm text-gray-700 dark:text-gray-300">
+        <Label htmlFor="keep-settings" className="text-sm text-gray-700 dark:text-gray-300">
           Keep current settings
-        </label>
+        </Label>
         <Switch id="keep-settings" label="Keep settings" {...register('keep_settings')} />
       </div>
       <Button

--- a/frontend/src/pages/system/hardware-buttons-card.tsx
+++ b/frontend/src/pages/system/hardware-buttons-card.tsx
@@ -62,7 +62,7 @@ export function HardwareButtonsCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Hardware Buttons</CardTitle>
+        <CardTitle>Hardware Buttons</CardTitle>
         <ToggleLeft className="h-4 w-4 text-gray-500" />
       </CardHeader>
 

--- a/frontend/src/pages/system/hardware-buttons-card.tsx
+++ b/frontend/src/pages/system/hardware-buttons-card.tsx
@@ -63,11 +63,11 @@ export function HardwareButtonsCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Hardware Buttons</CardTitle>
-        <ToggleLeft className="h-4 w-4 text-gray-500" />
+        <ToggleLeft className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
 
       <CardContent className="space-y-4">
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
           Configure what each physical button does when pressed.
         </p>
 

--- a/frontend/src/pages/system/led-control-card.tsx
+++ b/frontend/src/pages/system/led-control-card.tsx
@@ -73,7 +73,7 @@ export function LEDControlCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">LED Control</CardTitle>
+        <CardTitle>LED Control</CardTitle>
         <Lightbulb className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/system/led-control-card.tsx
+++ b/frontend/src/pages/system/led-control-card.tsx
@@ -74,7 +74,7 @@ export function LEDControlCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>LED Control</CardTitle>
-        <Lightbulb className="h-4 w-4 text-gray-500" />
+        <Lightbulb className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         <LedStealthStatusPanel

--- a/frontend/src/pages/system/led-schedule-form.tsx
+++ b/frontend/src/pages/system/led-schedule-form.tsx
@@ -2,6 +2,7 @@ import type { FieldErrors, UseFormHandleSubmit, UseFormRegister } from 'react-ho
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import type { LedScheduleFormValues } from '@/lib/schemas/system-forms';
 
 type LedScheduleFormProps = {
@@ -40,9 +41,9 @@ export function LedScheduleForm({
       {scheduleEnabled && (
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            <label htmlFor="led-on-time" className="w-16 text-xs text-gray-600 dark:text-gray-400">
+            <Label htmlFor="led-on-time" className="w-16">
               LEDs On
-            </label>
+            </Label>
             <Input
               id="led-on-time"
               type="time"
@@ -58,9 +59,9 @@ export function LedScheduleForm({
             </p>
           ) : null}
           <div className="flex items-center gap-3">
-            <label htmlFor="led-off-time" className="w-16 text-xs text-gray-600 dark:text-gray-400">
+            <Label htmlFor="led-off-time" className="w-16">
               LEDs Off
-            </label>
+            </Label>
             <Input
               id="led-off-time"
               type="time"

--- a/frontend/src/pages/system/led-schedule-form.tsx
+++ b/frontend/src/pages/system/led-schedule-form.tsx
@@ -1,5 +1,6 @@
 import type { FieldErrors, UseFormHandleSubmit, UseFormRegister } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
+import { CardInset } from '@/components/ui/card-inset';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -30,68 +31,72 @@ export function LedScheduleForm({
   removePending,
 }: LedScheduleFormProps) {
   return (
-    <form onSubmit={handleSubmit(onSave)} className="space-y-3 rounded-lg border p-3" noValidate>
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm font-medium text-gray-900 dark:text-white">LED Schedule</p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">Automatically turn LEDs on/off at set times</p>
+    <CardInset>
+      <form onSubmit={handleSubmit(onSave)} className="space-y-3" noValidate>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-900 dark:text-white">LED Schedule</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Automatically turn LEDs on/off at set times
+            </p>
+          </div>
+          <Switch id="led-schedule" label="Enable schedule" {...register('enabled')} />
         </div>
-        <Switch id="led-schedule" label="Enable schedule" {...register('enabled')} />
-      </div>
-      {scheduleEnabled && (
-        <div className="space-y-2">
-          <div className="flex items-center gap-3">
-            <Label htmlFor="led-on-time" className="w-16">
-              LEDs On
-            </Label>
-            <Input
-              id="led-on-time"
-              type="time"
-              className="w-32"
-              aria-invalid={!!errors.on_time}
-              aria-describedby={errors.on_time ? 'led-on-err' : undefined}
-              {...register('on_time')}
-            />
+        {scheduleEnabled && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-3">
+              <Label htmlFor="led-on-time" className="w-16">
+                LEDs On
+              </Label>
+              <Input
+                id="led-on-time"
+                type="time"
+                className="w-32"
+                aria-invalid={!!errors.on_time}
+                aria-describedby={errors.on_time ? 'led-on-err' : undefined}
+                {...register('on_time')}
+              />
+            </div>
+            {errors.on_time ? (
+              <p id="led-on-err" className="text-xs text-red-500" role="alert">
+                {errors.on_time.message}
+              </p>
+            ) : null}
+            <div className="flex items-center gap-3">
+              <Label htmlFor="led-off-time" className="w-16">
+                LEDs Off
+              </Label>
+              <Input
+                id="led-off-time"
+                type="time"
+                className="w-32"
+                aria-invalid={!!errors.off_time}
+                aria-describedby={errors.off_time ? 'led-off-err' : undefined}
+                {...register('off_time')}
+              />
+            </div>
+            {errors.off_time ? (
+              <p id="led-off-err" className="text-xs text-red-500" role="alert">
+                {errors.off_time.message}
+              </p>
+            ) : null}
+            <Button type="submit" disabled={savePending}>
+              {savePending ? 'Saving...' : 'Save Schedule'}
+            </Button>
           </div>
-          {errors.on_time ? (
-            <p id="led-on-err" className="text-xs text-red-500" role="alert">
-              {errors.on_time.message}
-            </p>
-          ) : null}
-          <div className="flex items-center gap-3">
-            <Label htmlFor="led-off-time" className="w-16">
-              LEDs Off
-            </Label>
-            <Input
-              id="led-off-time"
-              type="time"
-              className="w-32"
-              aria-invalid={!!errors.off_time}
-              aria-describedby={errors.off_time ? 'led-off-err' : undefined}
-              {...register('off_time')}
-            />
-          </div>
-          {errors.off_time ? (
-            <p id="led-off-err" className="text-xs text-red-500" role="alert">
-              {errors.off_time.message}
-            </p>
-          ) : null}
-          <Button size="sm" type="submit" disabled={savePending}>
-            {savePending ? 'Saving...' : 'Save Schedule'}
+        )}
+        {!scheduleEnabled && serverScheduleActive && (
+          <Button
+            size="sm"
+            type="button"
+            variant="outline"
+            disabled={removePending}
+            onClick={onRemoveSchedule}
+          >
+            Remove Schedule
           </Button>
-        </div>
-      )}
-      {!scheduleEnabled && serverScheduleActive && (
-        <Button
-          size="sm"
-          type="button"
-          variant="outline"
-          disabled={removePending}
-          onClick={onRemoveSchedule}
-        >
-          Remove Schedule
-        </Button>
-      )}
-    </form>
+        )}
+      </form>
+    </CardInset>
   );
 }

--- a/frontend/src/pages/system/led-schedule-form.tsx
+++ b/frontend/src/pages/system/led-schedule-form.tsx
@@ -34,7 +34,7 @@ export function LedScheduleForm({
       <div className="flex items-center justify-between">
         <div>
           <p className="text-sm font-medium text-gray-900 dark:text-white">LED Schedule</p>
-          <p className="text-xs text-gray-500">Automatically turn LEDs on/off at set times</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">Automatically turn LEDs on/off at set times</p>
         </div>
         <Switch id="led-schedule" label="Enable schedule" {...register('enabled')} />
       </div>

--- a/frontend/src/pages/system/led-stealth-status-panel.tsx
+++ b/frontend/src/pages/system/led-stealth-status-panel.tsx
@@ -36,7 +36,7 @@ export function LedStealthStatusPanel({
 
       {ledStatus.leds && ledStatus.leds.length > 0 && (
         <div className="space-y-1">
-          <p className="text-xs font-medium text-gray-500">Individual LEDs</p>
+          <p className="text-xs font-medium text-gray-500 dark:text-gray-400">Individual LEDs</p>
           <div className="grid gap-1">
             {ledStatus.leds.map((led) => (
               <div

--- a/frontend/src/pages/system/ntp-config-card.tsx
+++ b/frontend/src/pages/system/ntp-config-card.tsx
@@ -98,7 +98,7 @@ export function NTPConfigCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">NTP Configuration</CardTitle>
+        <CardTitle>NTP Configuration</CardTitle>
         <Clock className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/system/ntp-config-card.tsx
+++ b/frontend/src/pages/system/ntp-config-card.tsx
@@ -99,7 +99,7 @@ export function NTPConfigCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>NTP Configuration</CardTitle>
-        <Clock className="h-4 w-4 text-gray-500" />
+        <Clock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {ntpLoading ? (

--- a/frontend/src/pages/system/ntp-config-edit-form.tsx
+++ b/frontend/src/pages/system/ntp-config-edit-form.tsx
@@ -7,6 +7,7 @@ import type {
 } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import type { NtpConfigFormValues, NtpServerDraftFormValues } from '@/lib/schemas/system-forms';
 import { NtpConfigServerFields } from '@/pages/system/ntp-config-server-fields';
 
@@ -42,9 +43,9 @@ export function NtpConfigEditForm({
   return (
     <form onSubmit={handleSubmit(onSave)} className="space-y-4" noValidate>
       <div className="flex items-center justify-between">
-        <label htmlFor="ntp-enabled" className="text-sm text-gray-700 dark:text-gray-300">
+        <Label htmlFor="ntp-enabled" className="text-sm text-gray-700 dark:text-gray-300">
           Enable NTP time synchronization
-        </label>
+        </Label>
         <Switch id="ntp-enabled" label="Enable NTP" {...register('enabled')} />
       </div>
 

--- a/frontend/src/pages/system/ntp-config-server-fields.tsx
+++ b/frontend/src/pages/system/ntp-config-server-fields.tsx
@@ -6,6 +6,7 @@ import type {
 } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { NtpConfigFormValues, NtpServerDraftFormValues } from '@/lib/schemas/system-forms';
 
 type NtpConfigServerFieldsProps = {
@@ -27,7 +28,7 @@ export function NtpConfigServerFields({
 }: NtpConfigServerFieldsProps) {
   return (
     <div className="space-y-2">
-      <label className="text-xs text-gray-500">NTP Servers</label>
+      <Label>NTP Servers</Label>
       {fields.map((field, index) => (
         <div key={field.id} className="flex items-center gap-2">
           <Input

--- a/frontend/src/pages/system/ntp-config-server-fields.tsx
+++ b/frontend/src/pages/system/ntp-config-server-fields.tsx
@@ -4,6 +4,7 @@ import type {
   UseFieldArrayReturn,
   UseFormReturn,
 } from 'react-hook-form';
+import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -32,18 +33,18 @@ export function NtpConfigServerFields({
       {fields.map((field, index) => (
         <div key={field.id} className="flex items-center gap-2">
           <Input
-            className="h-8 text-sm"
             aria-invalid={!!errors.servers?.[index]?.value}
             {...register(`servers.${index}.value` as const)}
           />
           <Button
             type="button"
-            size="sm"
+            size="icon"
             variant="ghost"
-            className="h-8 px-2 text-red-500 hover:text-red-700"
+            className="shrink-0 text-red-500 hover:text-red-700"
             onClick={() => remove(index)}
+            aria-label={`Remove NTP server ${index + 1}`}
           >
-            Remove
+            <Trash2 className="h-4 w-4" />
           </Button>
         </div>
       ))}
@@ -51,7 +52,6 @@ export function NtpConfigServerFields({
       <div className="flex flex-wrap items-end gap-2">
         <div className="flex flex-col gap-0.5">
           <Input
-            className="h-8 text-sm"
             placeholder="Add NTP server address"
             aria-invalid={addServerForm.formState.errors.server ? 'true' : undefined}
             aria-describedby={addServerForm.formState.errors.server ? 'ntp-draft-err' : undefined}
@@ -74,9 +74,7 @@ export function NtpConfigServerFields({
         </div>
         <Button
           type="button"
-          size="sm"
           variant="outline"
-          className="h-8"
           onClick={() =>
             addServerForm.handleSubmit((d) => {
               append({ value: d.server });

--- a/frontend/src/pages/system/ntp-config-summary-view.tsx
+++ b/frontend/src/pages/system/ntp-config-summary-view.tsx
@@ -21,14 +21,14 @@ export function NtpConfigSummaryView({
     <div className="space-y-3">
       <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
         <div className="flex items-center justify-between">
-          <span className="text-gray-500">NTP</span>
+          <span className="text-gray-500 dark:text-gray-400">NTP</span>
           <span className="text-gray-900 dark:text-white">
             {ntpEnabled ? 'Enabled' : 'Disabled'}
           </span>
         </div>
 
         <div className="mt-2">
-          <div className="text-xs text-gray-500">Servers</div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">Servers</div>
           <div className="mt-1 font-mono text-sm text-gray-900 dark:text-white">
             {serversSummary}
           </div>

--- a/frontend/src/pages/system/ssh-key-add-form.tsx
+++ b/frontend/src/pages/system/ssh-key-add-form.tsx
@@ -14,7 +14,7 @@ export function SSHKeyAddForm({ register, errors, onSubmit, addPending }: SSHKey
     <form onSubmit={onSubmit} className="space-y-2 pt-2" noValidate>
       <p className="text-sm font-medium">Add a new public key</p>
       <textarea
-        className="h-24 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        className="h-24 w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-xs text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
         placeholder="ssh-ed25519 AAAA… user@host"
         spellCheck={false}
         aria-invalid={!!errors.key}
@@ -22,7 +22,7 @@ export function SSHKeyAddForm({ register, errors, onSubmit, addPending }: SSHKey
         {...register('key')}
       />
       {errors.key ? (
-        <p id="ssh-key-error" className="text-xs text-destructive" role="alert">
+        <p id="ssh-key-error" className="text-xs text-red-500" role="alert">
           {errors.key.message}
         </p>
       ) : null}

--- a/frontend/src/pages/system/ssh-keys-card.tsx
+++ b/frontend/src/pages/system/ssh-keys-card.tsx
@@ -35,11 +35,9 @@ export function SSHKeysCard() {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Key className="h-5 w-5" />
-          SSH Public Keys
-        </CardTitle>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle>SSH Public Keys</CardTitle>
+        <Key className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         {isLoading ? (

--- a/frontend/src/pages/system/ssh-keys-card.tsx
+++ b/frontend/src/pages/system/ssh-keys-card.tsx
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Key } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useSSHKeys, useAddSSHKey, useDeleteSSHKey } from '@/hooks/use-system';
 import { sshPublicKeyFormSchema, type SshPublicKeyFormValues } from '@/lib/schemas/system-forms';
 import { SSHKeyAddForm } from '@/pages/system/ssh-key-add-form';
@@ -42,7 +43,7 @@ export function SSHKeysCard() {
       </CardHeader>
       <CardContent className="space-y-4">
         {isLoading ? (
-          <p className="text-sm text-muted-foreground">Loading…</p>
+          <Skeleton className="h-16 w-full" />
         ) : (
           <SSHKeysList
             keys={[...keys]}

--- a/frontend/src/pages/system/ssh-keys-list.tsx
+++ b/frontend/src/pages/system/ssh-keys-list.tsx
@@ -27,16 +27,16 @@ export function SSHKeysList({ keys, deletePending, onDelete }: SSHKeysListProps)
               <Badge variant="secondary" className="shrink-0 font-mono text-xs">
                 {k.key.split(' ')[0] ?? 'key'}
               </Badge>
-              {k.comment && <span className="truncate text-sm text-foreground">{k.comment}</span>}
+              {k.comment && <span className="truncate text-sm">{k.comment}</span>}
             </div>
-            <p className="mt-1 truncate font-mono text-xs text-muted-foreground">
+            <p className="mt-1 truncate font-mono text-xs text-gray-500 dark:text-gray-400">
               {k.key.slice(0, 40)}…
             </p>
           </div>
           <Button
             variant="ghost"
             size="icon"
-            className="shrink-0 text-destructive hover:text-destructive"
+            className="shrink-0 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
             disabled={deletePending}
             onClick={() => onDelete(k.index)}
             aria-label="Delete SSH key"

--- a/frontend/src/pages/system/ssh-keys-list.tsx
+++ b/frontend/src/pages/system/ssh-keys-list.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 import type { SSHKey } from '@shared/index';
 
 type SSHKeysListProps = {
@@ -11,7 +12,7 @@ type SSHKeysListProps = {
 
 export function SSHKeysList({ keys, deletePending, onDelete }: SSHKeysListProps) {
   if (keys.length === 0) {
-    return <p className="text-sm text-muted-foreground">No keys configured</p>;
+    return <EmptyState message="No keys configured" />;
   }
 
   return (

--- a/frontend/src/pages/system/system-at-a-glance-section.tsx
+++ b/frontend/src/pages/system/system-at-a-glance-section.tsx
@@ -19,7 +19,7 @@ export function SystemAtAGlanceSection() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle>System Information</CardTitle>
-            <Server className="h-4 w-4 text-gray-500" />
+            <Server className="h-4 w-4 text-gray-500 dark:text-gray-400" />
           </CardHeader>
           <CardContent>
             {infoLoading ? (
@@ -30,17 +30,17 @@ export function SystemAtAGlanceSection() {
             ) : info ? (
               <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
                 <div className="grid grid-cols-2 gap-2">
-                  <span className="text-gray-500">Hostname</span>
+                  <span className="text-gray-500 dark:text-gray-400">Hostname</span>
                   <span className="flex items-center gap-1 text-gray-900 dark:text-white">
                     <HostnameInlineForm hostname={info.hostname} onUpdated={() => refetchInfo()} />
                   </span>
-                  <span className="text-gray-500">Model</span>
+                  <span className="text-gray-500 dark:text-gray-400">Model</span>
                   <span className="text-gray-900 dark:text-white">{info.model}</span>
-                  <span className="text-gray-500">Firmware</span>
+                  <span className="text-gray-500 dark:text-gray-400">Firmware</span>
                   <span className="text-gray-900 dark:text-white">{info.firmware_version}</span>
-                  <span className="text-gray-500">Kernel</span>
+                  <span className="text-gray-500 dark:text-gray-400">Kernel</span>
                   <span className="text-gray-900 dark:text-white">{info.kernel_version}</span>
-                  <span className="text-gray-500">Uptime</span>
+                  <span className="text-gray-500 dark:text-gray-400">Uptime</span>
                   <span className="text-gray-900 dark:text-white">
                     {formatUptime(info.uptime_seconds)}
                   </span>
@@ -53,7 +53,7 @@ export function SystemAtAGlanceSection() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle>System Stats</CardTitle>
-            <Cpu className="h-4 w-4 text-gray-500" />
+            <Cpu className="h-4 w-4 text-gray-500 dark:text-gray-400" />
           </CardHeader>
           <CardContent className="space-y-4">
             {statsLoading ? (
@@ -70,14 +70,14 @@ export function SystemAtAGlanceSection() {
                     <span className="text-gray-900 dark:text-white">
                       {stats.cpu.usage_percent.toFixed(1)}%
                       {stats.cpu.temperature_celsius != null && (
-                        <span className="ml-2 text-gray-500">
+                        <span className="ml-2 text-gray-500 dark:text-gray-400">
                           {stats.cpu.temperature_celsius}°C
                         </span>
                       )}
                     </span>
                   </div>
                   <Progress value={stats.cpu.usage_percent} />
-                  <p className="mt-0.5 text-xs text-gray-500">
+                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
                     Load: {stats.cpu.load_average.map((v) => v.toFixed(2)).join(', ')} ·{' '}
                     {stats.cpu.cores} cores
                   </p>

--- a/frontend/src/pages/system/system-at-a-glance-section.tsx
+++ b/frontend/src/pages/system/system-at-a-glance-section.tsx
@@ -18,7 +18,7 @@ export function SystemAtAGlanceSection() {
       <div className="space-y-4">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">System Information</CardTitle>
+            <CardTitle>System Information</CardTitle>
             <Server className="h-4 w-4 text-gray-500" />
           </CardHeader>
           <CardContent>
@@ -52,7 +52,7 @@ export function SystemAtAGlanceSection() {
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">System Stats</CardTitle>
+            <CardTitle>System Stats</CardTitle>
             <Cpu className="h-4 w-4 text-gray-500" />
           </CardHeader>
           <CardContent className="space-y-4">

--- a/frontend/src/pages/system/system-backup-restore-card.tsx
+++ b/frontend/src/pages/system/system-backup-restore-card.tsx
@@ -16,7 +16,7 @@ export function SystemBackupRestoreCard() {
     <>
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Backup & Restore</CardTitle>
+          <CardTitle>Backup & Restore</CardTitle>
           <Download className="h-4 w-4 text-gray-500" />
         </CardHeader>
         <CardContent>

--- a/frontend/src/pages/system/system-backup-restore-card.tsx
+++ b/frontend/src/pages/system/system-backup-restore-card.tsx
@@ -17,7 +17,7 @@ export function SystemBackupRestoreCard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Backup & Restore</CardTitle>
-          <Download className="h-4 w-4 text-gray-500" />
+          <Download className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <div className="space-y-3">

--- a/frontend/src/pages/system/system-power-section.tsx
+++ b/frontend/src/pages/system/system-power-section.tsx
@@ -20,7 +20,7 @@ export function SystemPowerSection() {
         </h2>
         <Card className="border-red-200 dark:border-red-900">
           <CardContent className="space-y-4 pt-4">
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               These actions are irreversible or will cause a service interruption. Proceed with
               caution.
             </p>
@@ -39,7 +39,7 @@ export function SystemPowerSection() {
                 Factory Reset
               </Button>
             </div>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Shut Down powers off the device — you will need physical access to turn it back on.
             </p>
           </CardContent>

--- a/frontend/src/pages/system/system-timezone-card.tsx
+++ b/frontend/src/pages/system/system-timezone-card.tsx
@@ -22,7 +22,7 @@ export function SystemTimezoneCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Time & Timezone</CardTitle>
+        <CardTitle>Time & Timezone</CardTitle>
         <Clock className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/system/system-timezone-card.tsx
+++ b/frontend/src/pages/system/system-timezone-card.tsx
@@ -24,7 +24,7 @@ export function SystemTimezoneCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Time & Timezone</CardTitle>
-        <Clock className="h-4 w-4 text-gray-500" />
+        <Clock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {tzLoading ? (
@@ -33,7 +33,7 @@ export function SystemTimezoneCard() {
           <div className="space-y-4">
             <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
               <div className="grid grid-cols-2 gap-2">
-                <span className="text-gray-500">Timezone</span>
+                <span className="text-gray-500 dark:text-gray-400">Timezone</span>
                 <span className="text-gray-900 dark:text-white">
                   {timezoneConfig?.zonename || '—'}
                 </span>

--- a/frontend/src/pages/system/system-timezone-card.tsx
+++ b/frontend/src/pages/system/system-timezone-card.tsx
@@ -3,6 +3,7 @@ import { Clock } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -42,7 +43,7 @@ export function SystemTimezoneCard() {
             {editingTimezone ? (
               <>
                 <div className="space-y-1">
-                  <label className="text-xs text-gray-500">Change Timezone</label>
+                  <Label>Change Timezone</Label>
                   <Select
                     value={selectedTz || timezoneConfig?.zonename || ''}
                     onValueChange={setSelectedTz}

--- a/frontend/src/pages/vpn/split-tunnel-card.tsx
+++ b/frontend/src/pages/vpn/split-tunnel-card.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { GitFork } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useSplitTunnel, useSetSplitTunnel } from '@/hooks/use-vpn';
 import { splitTunnelFormSchema, type SplitTunnelFormValues } from '@/lib/schemas/vpn-forms';
 
@@ -47,7 +48,7 @@ export function SplitTunnelCard() {
           <GitFork className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
-          <div className="h-16 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          <Skeleton className="h-16 w-full" />
         </CardContent>
       </Card>
     );

--- a/frontend/src/pages/vpn/split-tunnel-card.tsx
+++ b/frontend/src/pages/vpn/split-tunnel-card.tsx
@@ -5,6 +5,7 @@ import { GitFork } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Label } from '@/components/ui/label';
 import { useSplitTunnel, useSetSplitTunnel } from '@/hooks/use-vpn';
 import { splitTunnelFormSchema, type SplitTunnelFormValues } from '@/lib/schemas/vpn-forms';
 
@@ -89,9 +90,9 @@ export function SplitTunnelCard() {
 
           {mode === 'custom' && (
             <div className="space-y-1.5">
-              <label className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              <Label>
                 CIDR ranges (comma-separated)
-              </label>
+              </Label>
               <textarea
                 placeholder="e.g. 10.0.0.0/8, 192.168.1.0/24"
                 rows={3}

--- a/frontend/src/pages/vpn/split-tunnel-card.tsx
+++ b/frontend/src/pages/vpn/split-tunnel-card.tsx
@@ -63,7 +63,7 @@ export function SplitTunnelCard() {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSave)} className="space-y-4" noValidate>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
             Control which traffic is routed through the WireGuard VPN.
           </p>
 
@@ -96,7 +96,7 @@ export function SplitTunnelCard() {
               <textarea
                 placeholder="e.g. 10.0.0.0/8, 192.168.1.0/24"
                 rows={3}
-                className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-xs text-gray-900 shadow-sm placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500"
                 {...register('routes_text')}
               />
               <p className="text-xs text-gray-400">

--- a/frontend/src/pages/vpn/split-tunnel-card.tsx
+++ b/frontend/src/pages/vpn/split-tunnel-card.tsx
@@ -43,7 +43,7 @@ export function SplitTunnelCard() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Split Tunneling</CardTitle>
+          <CardTitle>Split Tunneling</CardTitle>
           <GitFork className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
@@ -56,7 +56,7 @@ export function SplitTunnelCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Split Tunneling</CardTitle>
+        <CardTitle>Split Tunneling</CardTitle>
         <GitFork className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/vpn/split-tunnel-card.tsx
+++ b/frontend/src/pages/vpn/split-tunnel-card.tsx
@@ -46,7 +46,7 @@ export function SplitTunnelCard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Split Tunneling</CardTitle>
-          <GitFork className="h-4 w-4 text-gray-400" />
+          <GitFork className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <Skeleton className="h-16 w-full" />
@@ -59,7 +59,7 @@ export function SplitTunnelCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Split Tunneling</CardTitle>
-        <GitFork className="h-4 w-4 text-gray-400" />
+        <GitFork className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSave)} className="space-y-4" noValidate>

--- a/frontend/src/pages/vpn/vpn-dns-leak-test-card.tsx
+++ b/frontend/src/pages/vpn/vpn-dns-leak-test-card.tsx
@@ -20,10 +20,10 @@ export function VpnDnsLeakTestCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>DNS Leak Test</CardTitle>
-        <ShieldCheck className="h-4 w-4 text-gray-500" />
+        <ShieldCheck className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-3">
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
           Verify that DNS queries are routed through the VPN and not leaking to your ISP.
         </p>
 
@@ -63,7 +63,7 @@ export function VpnDnsLeakTestCard() {
             )}
 
             <div>
-              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500">
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 Active DNS Servers
               </p>
               {result.nameservers.length > 0 ? (
@@ -81,7 +81,7 @@ export function VpnDnsLeakTestCard() {
 
             {result.vpn_dns_servers.length > 0 && (
               <div>
-                <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500">
+                <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
                   VPN DNS Servers
                 </p>
                 <ul className="space-y-0.5">

--- a/frontend/src/pages/vpn/vpn-dns-leak-test-card.tsx
+++ b/frontend/src/pages/vpn/vpn-dns-leak-test-card.tsx
@@ -19,7 +19,7 @@ export function VpnDnsLeakTestCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">DNS Leak Test</CardTitle>
+        <CardTitle>DNS Leak Test</CardTitle>
         <ShieldCheck className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-3">

--- a/frontend/src/pages/vpn/vpn-speed-test-card.tsx
+++ b/frontend/src/pages/vpn/vpn-speed-test-card.tsx
@@ -10,7 +10,7 @@ export function VpnSpeedTestCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">VPN Speed Test</CardTitle>
+        <CardTitle>VPN Speed Test</CardTitle>
         <Gauge className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/vpn/vpn-speed-test-card.tsx
+++ b/frontend/src/pages/vpn/vpn-speed-test-card.tsx
@@ -12,7 +12,7 @@ export function VpnSpeedTestCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>VPN Speed Test</CardTitle>
-        <Gauge className="h-4 w-4 text-gray-500" />
+        <Gauge className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-gray-500 dark:text-gray-400">

--- a/frontend/src/pages/vpn/vpn-speed-test-card.tsx
+++ b/frontend/src/pages/vpn/vpn-speed-test-card.tsx
@@ -2,6 +2,7 @@ import { Gauge } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { InlineError } from '@/components/ui/inline-error';
 import { useRunWireGuardSpeedTest } from '@/hooks/use-vpn';
 
 export function VpnSpeedTestCard() {
@@ -46,11 +47,7 @@ export function VpnSpeedTestCard() {
           </div>
         )}
 
-        {speedTest.isError && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300">
-            {speedTest.error.message}
-          </div>
-        )}
+        {speedTest.isError && <InlineError>{speedTest.error.message}</InlineError>}
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
+++ b/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
@@ -40,7 +40,7 @@ export function VpnVerifyWireguardCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Verify VPN</CardTitle>
+        <CardTitle>Verify VPN</CardTitle>
         <ShieldCheck className="h-4 w-4 text-gray-500" />
       </CardHeader>
       <CardContent className="space-y-3">

--- a/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
+++ b/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
@@ -71,13 +71,9 @@ export function VpnVerifyWireguardCard() {
           <div className="space-y-2 pt-1">
             <div className="flex items-center gap-2">
               {allOk ? (
-                <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                  All checks passed
-                </Badge>
+                <Badge variant="success">All checks passed</Badge>
               ) : (
-                <Badge className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
-                  Issues detected
-                </Badge>
+                <Badge variant="destructive">Issues detected</Badge>
               )}
             </div>
             <div className="space-y-1.5 rounded-md bg-gray-50 p-3 dark:bg-gray-800">

--- a/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
+++ b/frontend/src/pages/vpn/vpn-verify-wireguard-card.tsx
@@ -41,10 +41,10 @@ export function VpnVerifyWireguardCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Verify VPN</CardTitle>
-        <ShieldCheck className="h-4 w-4 text-gray-500" />
+        <ShieldCheck className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-3">
-        <p className="text-sm text-gray-500">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
           Check that the WireGuard tunnel, routes, and firewall rules are correctly configured.
         </p>
 

--- a/frontend/src/pages/vpn/wireguard-config-peers-list.tsx
+++ b/frontend/src/pages/vpn/wireguard-config-peers-list.tsx
@@ -1,4 +1,5 @@
 import type { WireguardConfig } from '@shared/index';
+import { CardInset } from '@/components/ui/card-inset';
 
 type WireguardConfigPeersListProps = {
   config: WireguardConfig | undefined;
@@ -16,26 +17,25 @@ export function WireguardConfigPeersList({ config }: WireguardConfigPeersListPro
       </h4>
       <ul className="space-y-2" role="list">
         {config.peers.map((peer) => (
-          <li
-            key={peer.public_key}
-            className="rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700"
-          >
-            <div className="grid grid-cols-2 gap-1">
-              <span className="text-gray-500 dark:text-gray-400">Endpoint</span>
-              <span className="text-gray-900 dark:text-white">{peer.endpoint}</span>
-              <span className="text-gray-500 dark:text-gray-400">Allowed IPs</span>
-              <span className="text-gray-900 dark:text-white">
-                {(peer.allowed_ips ?? []).join(', ')}
-              </span>
-              {peer.last_handshake && (
-                <>
-                  <span className="text-gray-500 dark:text-gray-400">Last Handshake</span>
-                  <span className="text-gray-900 dark:text-white">
-                    {new Date(peer.last_handshake).toLocaleString()}
-                  </span>
-                </>
-              )}
-            </div>
+          <li key={peer.public_key}>
+            <CardInset className="text-sm">
+              <div className="grid grid-cols-2 gap-1">
+                <span className="text-gray-500 dark:text-gray-400">Endpoint</span>
+                <span className="text-gray-900 dark:text-white">{peer.endpoint}</span>
+                <span className="text-gray-500 dark:text-gray-400">Allowed IPs</span>
+                <span className="text-gray-900 dark:text-white">
+                  {(peer.allowed_ips ?? []).join(', ')}
+                </span>
+                {peer.last_handshake && (
+                  <>
+                    <span className="text-gray-500 dark:text-gray-400">Last Handshake</span>
+                    <span className="text-gray-900 dark:text-white">
+                      {new Date(peer.last_handshake).toLocaleString()}
+                    </span>
+                  </>
+                )}
+              </div>
+            </CardInset>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/vpn/wireguard-config-peers-list.tsx
+++ b/frontend/src/pages/vpn/wireguard-config-peers-list.tsx
@@ -21,15 +21,15 @@ export function WireguardConfigPeersList({ config }: WireguardConfigPeersListPro
             className="rounded-md border border-gray-200 p-3 text-sm dark:border-gray-700"
           >
             <div className="grid grid-cols-2 gap-1">
-              <span className="text-gray-500">Endpoint</span>
+              <span className="text-gray-500 dark:text-gray-400">Endpoint</span>
               <span className="text-gray-900 dark:text-white">{peer.endpoint}</span>
-              <span className="text-gray-500">Allowed IPs</span>
+              <span className="text-gray-500 dark:text-gray-400">Allowed IPs</span>
               <span className="text-gray-900 dark:text-white">
                 {(peer.allowed_ips ?? []).join(', ')}
               </span>
               {peer.last_handshake && (
                 <>
-                  <span className="text-gray-500">Last Handshake</span>
+                  <span className="text-gray-500 dark:text-gray-400">Last Handshake</span>
                   <span className="text-gray-900 dark:text-white">
                     {new Date(peer.last_handshake).toLocaleString()}
                   </span>

--- a/frontend/src/pages/vpn/wireguard-connection-stats-panels.tsx
+++ b/frontend/src/pages/vpn/wireguard-connection-stats-panels.tsx
@@ -17,17 +17,17 @@ export function WireguardConnectionStatsPanels({
         <h4 className="mb-2 font-medium text-gray-700 dark:text-gray-300">Connection Status</h4>
         {(wgLiveStatus.peers ?? []).map((peer) => (
           <div key={peer.public_key} className="grid grid-cols-2 gap-2">
-            <span className="text-gray-500">Endpoint</span>
+            <span className="text-gray-500 dark:text-gray-400">Endpoint</span>
             <span className="text-gray-900 dark:text-white">{peer.endpoint}</span>
-            <span className="text-gray-500">Last Handshake</span>
+            <span className="text-gray-500 dark:text-gray-400">Last Handshake</span>
             <span className="text-gray-900 dark:text-white">
               {formatWireguardHandshakeTime(peer.latest_handshake)}
             </span>
-            <span className="text-gray-500">RX</span>
+            <span className="text-gray-500 dark:text-gray-400">RX</span>
             <span className="text-gray-900 dark:text-white">{formatBytes(peer.transfer_rx)}</span>
-            <span className="text-gray-500">TX</span>
+            <span className="text-gray-500 dark:text-gray-400">TX</span>
             <span className="text-gray-900 dark:text-white">{formatBytes(peer.transfer_tx)}</span>
-            <span className="text-gray-500">Allowed IPs</span>
+            <span className="text-gray-500 dark:text-gray-400">Allowed IPs</span>
             <span className="text-gray-900 dark:text-white">{peer.allowed_ips}</span>
           </div>
         ))}
@@ -39,11 +39,11 @@ export function WireguardConnectionStatsPanels({
     return (
       <div className="rounded-md bg-gray-50 p-3 text-sm dark:bg-gray-900">
         <div className="grid grid-cols-2 gap-2">
-          <span className="text-gray-500">Endpoint</span>
+          <span className="text-gray-500 dark:text-gray-400">Endpoint</span>
           <span className="text-gray-900 dark:text-white">{wgStatus.endpoint}</span>
-          <span className="text-gray-500">RX</span>
+          <span className="text-gray-500 dark:text-gray-400">RX</span>
           <span className="text-gray-900 dark:text-white">{formatBytes(wgStatus.rx_bytes)}</span>
-          <span className="text-gray-500">TX</span>
+          <span className="text-gray-500 dark:text-gray-400">TX</span>
           <span className="text-gray-900 dark:text-white">{formatBytes(wgStatus.tx_bytes)}</span>
         </div>
       </div>

--- a/frontend/src/pages/vpn/wireguard-import-profile-form.tsx
+++ b/frontend/src/pages/vpn/wireguard-import-profile-form.tsx
@@ -85,7 +85,7 @@ export function WireguardImportProfileForm({
           {importErrors.config.message}
         </p>
       ) : null}
-      <Button type="submit" size="sm" disabled={isSaving}>
+      <Button type="submit" disabled={isSaving}>
         <Plus className="mr-1 h-4 w-4" />
         {isSaving ? 'Saving...' : 'Save Profile'}
       </Button>

--- a/frontend/src/pages/vpn/wireguard-import-profile-form.tsx
+++ b/frontend/src/pages/vpn/wireguard-import-profile-form.tsx
@@ -65,7 +65,7 @@ export function WireguardImportProfileForm({
           className="hidden"
           onChange={(e) => void onFileSelected(e.target.files?.[0] ?? null)}
         />
-        <span className="text-xs text-gray-500">or paste below</span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">or paste below</span>
       </div>
       <textarea
         className={cn(

--- a/frontend/src/pages/vpn/wireguard-install-prompt.tsx
+++ b/frontend/src/pages/vpn/wireguard-install-prompt.tsx
@@ -3,7 +3,7 @@ import { Link } from '@tanstack/react-router';
 export function WireguardInstallPrompt() {
   return (
     <div className="py-4 text-center">
-      <p className="mb-2 text-sm text-gray-500">WireGuard is not installed</p>
+      <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">WireGuard is not installed</p>
       <Link to="/services" className="text-sm text-blue-600 hover:underline dark:text-blue-400">
         Install via Services →
       </Link>

--- a/frontend/src/pages/vpn/wireguard-profiles-kill-import.tsx
+++ b/frontend/src/pages/vpn/wireguard-profiles-kill-import.tsx
@@ -2,6 +2,7 @@ import type { UseFormReturn } from 'react-hook-form';
 import { ShieldAlert, Trash2, Play } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CardInset } from '@/components/ui/card-inset';
 import { Switch } from '@/components/ui/switch';
 import type { WireGuardProfile, KillSwitchStatus } from '@shared/index';
 import type { WireguardProfileImportFormValues } from '@/lib/schemas/vpn-forms';
@@ -79,7 +80,7 @@ export function WireguardProfilesKillImport({
         </div>
       )}
 
-      <div className="rounded-md border border-gray-200 p-3 dark:border-gray-700">
+      <CardInset>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <ShieldAlert className="h-4 w-4 text-orange-500" />
@@ -99,7 +100,7 @@ export function WireguardProfilesKillImport({
             ? 'All traffic is blocked if VPN disconnects. Disable to allow direct internet access.'
             : 'When enabled, blocks all internet traffic if the VPN connection drops to prevent IP leaks.'}
         </p>
-      </div>
+      </CardInset>
 
       <WireguardImportProfileForm
         form={importForm}

--- a/frontend/src/pages/vpn/wireguard-profiles-kill-import.tsx
+++ b/frontend/src/pages/vpn/wireguard-profiles-kill-import.tsx
@@ -94,7 +94,7 @@ export function WireguardProfilesKillImport({
             disabled={killSwitchMutation.isPending}
           />
         </div>
-        <p className="mt-1 text-xs text-gray-500">
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
           {killSwitch?.enabled
             ? 'All traffic is blocked if VPN disconnects. Disable to allow direct internet access.'
             : 'When enabled, blocks all internet traffic if the VPN connection drops to prevent IP leaks.'}

--- a/frontend/src/pages/vpn/wireguard-section.tsx
+++ b/frontend/src/pages/vpn/wireguard-section.tsx
@@ -83,7 +83,7 @@ export function WireguardSection() {
       />
       <Card className={!isInstalled ? 'opacity-60' : undefined}>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">WireGuard</CardTitle>
+          <CardTitle>WireGuard</CardTitle>
           <Shield className="h-4 w-4 text-blue-500" />
         </CardHeader>
         <CardContent className="space-y-4">

--- a/frontend/src/pages/vpn/wireguard-status-detail-text.tsx
+++ b/frontend/src/pages/vpn/wireguard-status-detail-text.tsx
@@ -12,7 +12,7 @@ export function WireguardStatusDetailText({
   }
 
   return (
-    <div className="text-xs text-gray-500">
+    <div className="text-xs text-gray-500 dark:text-gray-400">
       {statusDetail === 'disabled' && 'WireGuard is disabled.'}
       {statusDetail === 'configured' && 'WireGuard is configured but not connected yet.'}
       {statusDetail === 'enabled_not_up' && 'WireGuard is enabled but the interface is not up yet.'}

--- a/frontend/src/pages/vpn/wireguard-status-toggle-row.tsx
+++ b/frontend/src/pages/vpn/wireguard-status-toggle-row.tsx
@@ -32,7 +32,7 @@ export function WireguardStatusToggleRow({
               : 'Disconnected'}
         </Badge>
         {isToggling && (
-          <span className="inline-flex items-center gap-1 text-xs text-gray-500">
+          <span className="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
             <Loader2 className="h-3 w-3 animate-spin" />
             Applying changes…
           </span>

--- a/frontend/src/pages/wifi/__tests__/wifi-page.test.tsx
+++ b/frontend/src/pages/wifi/__tests__/wifi-page.test.tsx
@@ -86,7 +86,7 @@ describe('WifiPage', () => {
     renderWifiPage();
 
     await waitFor(() => {
-      expect(screen.getByText('Scan Networks')).toBeInTheDocument();
+      expect(screen.getByText('Scan')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/wifi/ap-config-card.tsx
+++ b/frontend/src/pages/wifi/ap-config-card.tsx
@@ -53,7 +53,7 @@ export function APConfigCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium">Access Point Configuration</CardTitle>
+        <CardTitle>Access Point Configuration</CardTitle>
       </CardHeader>
       <CardContent>
         {apLoading ? (

--- a/frontend/src/pages/wifi/ap-config-card.tsx
+++ b/frontend/src/pages/wifi/ap-config-card.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { CardInset } from '@/components/ui/card-inset';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
@@ -71,7 +72,7 @@ export function APConfigCard() {
           />
         ) : (
           <div className="space-y-6">
-            <div className="flex items-center justify-between rounded-lg border p-3">
+            <CardInset className="flex items-center justify-between">
               <div className="space-y-0.5">
                 <span className="text-sm font-medium text-gray-900 dark:text-white">
                   Different settings per radio
@@ -87,7 +88,7 @@ export function APConfigCard() {
                 checked={separatePerRadio}
                 onChange={(e) => setSeparatePerRadio(e.target.checked)}
               />
-            </div>
+            </CardInset>
             {separatePerRadio ? (
               <div className="space-y-6">
                 {apConfigs.map((ap) => (

--- a/frontend/src/pages/wifi/ap-radio-form-credentials-and-actions.tsx
+++ b/frontend/src/pages/wifi/ap-radio-form-credentials-and-actions.tsx
@@ -9,6 +9,7 @@ import { QrCode } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -43,13 +44,13 @@ export function ApRadioFormCredentialsAndActions({
   return (
     <>
       <div className="space-y-2">
-        <label
+        <Label
           htmlFor={`ap-ssid-${ap.section}`}
-          className="flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400"
+          className="flex items-center gap-1"
         >
           SSID
           <InfoTooltip text="The name of your WiFi network that devices see when scanning. Keep it descriptive but avoid including personal information." />
-        </label>
+        </Label>
         <Input
           id={`ap-ssid-${ap.section}`}
           placeholder="Network name"
@@ -64,12 +65,11 @@ export function ApRadioFormCredentialsAndActions({
         ) : null}
       </div>
       <div className="space-y-2">
-        <label
+        <Label
           htmlFor={`ap-enc-${ap.section}`}
-          className="text-xs font-medium text-gray-600 dark:text-gray-400"
         >
           Encryption
-        </label>
+        </Label>
         <Controller
           name="encryption"
           control={control}
@@ -98,13 +98,13 @@ export function ApRadioFormCredentialsAndActions({
       </div>
       {encryption !== 'none' && (
         <div className="space-y-2">
-          <label
+          <Label
             htmlFor={`ap-key-${ap.section}`}
-            className="flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400"
+            className="flex items-center gap-1"
           >
             Password
             <InfoTooltip text="WiFi password (WPA key). Must be 8–63 characters for WPA2/WPA3. Avoid dictionary words — use a mix of letters, numbers, and symbols." />
-          </label>
+          </Label>
           <Input
             id={`ap-key-${ap.section}`}
             type="password"

--- a/frontend/src/pages/wifi/ap-radio-form-header-row.tsx
+++ b/frontend/src/pages/wifi/ap-radio-form-header-row.tsx
@@ -15,10 +15,10 @@ export function ApRadioFormHeaderRow({ ap, bandLabel, register }: ApRadioFormHea
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">
-        <Radio className="h-4 w-4 text-gray-500" />
+        <Radio className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         <span className="text-sm font-medium text-gray-900 dark:text-white">{ap.radio}</span>
         <Badge variant="outline">{bandLabel}</Badge>
-        <span className="text-xs text-gray-500">Ch {ap.channel}</span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">Ch {ap.channel}</span>
       </div>
       <Switch id={`ap-enabled-${ap.section}`} label="Enabled" {...register('enabled')} />
     </div>

--- a/frontend/src/pages/wifi/ap-radio-section.tsx
+++ b/frontend/src/pages/wifi/ap-radio-section.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { CardInset } from '@/components/ui/card-inset';
 import { WifiQRDialog } from '@/components/wifi/wifi-qr-dialog';
 import { useSetAPConfig } from '@/hooks/use-wifi';
 import type { APConfig, APConfigUpdate } from '@shared/index';
@@ -98,22 +99,20 @@ export function APRadioSection({ ap, activeEnabledCount, onEnabledChange }: APRa
 
   return (
     <>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="space-y-3 rounded-lg border p-4"
-        noValidate
-      >
-        <ApRadioFormFields
-          ap={ap}
-          bandLabel={bandLabel}
-          register={register}
-          control={control}
-          errors={errors}
-          encryption={encryption}
-          setValue={setValue}
-          savePending={setAP.isPending}
-          onOpenQr={openQrFromForm}
-        />
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <CardInset className="space-y-3 p-4">
+          <ApRadioFormFields
+            ap={ap}
+            bandLabel={bandLabel}
+            register={register}
+            control={control}
+            errors={errors}
+            encryption={encryption}
+            setValue={setValue}
+            savePending={setAP.isPending}
+            onOpenQr={openQrFromForm}
+          />
+        </CardInset>
       </form>
 
       <WifiQRDialog

--- a/frontend/src/pages/wifi/ap-unified-config-form.tsx
+++ b/frontend/src/pages/wifi/ap-unified-config-form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { QrCode, Radio } from 'lucide-react';
 import type { APConfig, APConfigUpdate } from '@shared/index';
 import { Button } from '@/components/ui/button';
+import { CardInset } from '@/components/ui/card-inset';
 import { Input } from '@/components/ui/input';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
 import { Badge } from '@/components/ui/badge';
@@ -168,7 +169,7 @@ export function APUnifiedConfigForm({
           </p>
         ) : null}
 
-        <div className="space-y-3 rounded-lg border p-4">
+        <CardInset className="space-y-3 p-4">
           {apConfigs.map((ap) => (
             <div
               key={ap.section}
@@ -190,7 +191,7 @@ export function APUnifiedConfigForm({
               />
             </div>
           ))}
-        </div>
+        </CardInset>
 
         <div className="space-y-2">
           <Label

--- a/frontend/src/pages/wifi/ap-unified-config-form.tsx
+++ b/frontend/src/pages/wifi/ap-unified-config-form.tsx
@@ -175,12 +175,12 @@ export function APUnifiedConfigForm({
               className="flex items-center justify-between border-b pb-3 last:border-0 last:pb-0"
             >
               <div className="flex items-center gap-2">
-                <Radio className="h-4 w-4 text-gray-500" />
+                <Radio className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                 <span className="text-sm font-medium text-gray-900 dark:text-white">
                   {ap.radio}
                 </span>
                 <Badge variant="outline">{bandLabel(ap.band)}</Badge>
-                <span className="text-xs text-gray-500">Ch {ap.channel}</span>
+                <span className="text-xs text-gray-500 dark:text-gray-400">Ch {ap.channel}</span>
               </div>
               <Switch
                 id={`ap-unified-enabled-${ap.section}`}

--- a/frontend/src/pages/wifi/ap-unified-config-form.tsx
+++ b/frontend/src/pages/wifi/ap-unified-config-form.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { InfoTooltip } from '@/components/ui/info-tooltip';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -192,13 +193,13 @@ export function APUnifiedConfigForm({
         </div>
 
         <div className="space-y-2">
-          <label
+          <Label
             htmlFor="ap-unified-ssid"
-            className="flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400"
+            className="flex items-center gap-1"
           >
             Network name (all bands)
             <InfoTooltip text="The name of your WiFi network that devices see when scanning. Keep it descriptive but avoid including personal information." />
-          </label>
+          </Label>
           <Input
             id="ap-unified-ssid"
             placeholder="SSID for all radios"
@@ -213,12 +214,11 @@ export function APUnifiedConfigForm({
         </div>
 
         <div className="space-y-2">
-          <label
+          <Label
             htmlFor="ap-unified-enc"
-            className="text-xs font-medium text-gray-600 dark:text-gray-400"
           >
             Encryption
-          </label>
+          </Label>
           <Controller
             name="encryption"
             control={control}
@@ -248,13 +248,13 @@ export function APUnifiedConfigForm({
 
         {encryption !== 'none' && (
           <div className="space-y-2">
-            <label
+            <Label
               htmlFor="ap-unified-key"
-              className="flex items-center gap-1 text-xs font-medium text-gray-600 dark:text-gray-400"
+              className="flex items-center gap-1"
             >
               Password
               <InfoTooltip text="WiFi password (WPA key). Must be 8–63 characters for WPA2/WPA3. Avoid dictionary words — use a mix of letters, numbers, and symbols." />
-            </label>
+            </Label>
             <Input
               id="ap-unified-key"
               type="password"

--- a/frontend/src/pages/wifi/band-switching-card.tsx
+++ b/frontend/src/pages/wifi/band-switching-card.tsx
@@ -18,7 +18,7 @@ export function BandSwitchingCard() {
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">
             <p className="text-sm">Automatic band switching</p>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Switches between 2.4 GHz and 5 GHz based on signal quality
             </p>
           </div>
@@ -54,7 +54,7 @@ export function BandSwitchingCard() {
             </div>
             {bandSwitchData.status.state !== 'inactive' && (
               <div className="flex items-center gap-2 pt-1 border-t border-gray-200 dark:border-gray-700">
-                <span className="text-gray-500">Status:</span>
+                <span className="text-gray-500 dark:text-gray-400">Status:</span>
                 <Badge
                   variant={bandSwitchData.status.state === 'monitoring' ? 'success' : 'outline'}
                   className="text-xs"

--- a/frontend/src/pages/wifi/band-switching-card.tsx
+++ b/frontend/src/pages/wifi/band-switching-card.tsx
@@ -12,7 +12,7 @@ export function BandSwitchingCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Auto Band Switching</CardTitle>
-        <ChevronUp className="h-4 w-4 text-gray-400" />
+        <ChevronUp className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-center justify-between">

--- a/frontend/src/pages/wifi/band-switching-card.tsx
+++ b/frontend/src/pages/wifi/band-switching-card.tsx
@@ -11,7 +11,7 @@ export function BandSwitchingCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Auto Band Switching</CardTitle>
+        <CardTitle>Auto Band Switching</CardTitle>
         <ChevronUp className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-3">

--- a/frontend/src/pages/wifi/guest-network-card.tsx
+++ b/frontend/src/pages/wifi/guest-network-card.tsx
@@ -63,7 +63,7 @@ export function GuestNetworkCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Guest Network</CardTitle>
-        <ShieldCheck className="h-4 w-4 text-gray-400" />
+        <ShieldCheck className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {guestLoading ? (

--- a/frontend/src/pages/wifi/guest-network-card.tsx
+++ b/frontend/src/pages/wifi/guest-network-card.tsx
@@ -78,7 +78,7 @@ export function GuestNetworkCard() {
                 <span className="text-sm font-medium text-gray-900 dark:text-white">
                   Enable Guest WiFi
                 </span>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   Separate network (192.168.2.0/24) with client isolation
                 </p>
               </div>

--- a/frontend/src/pages/wifi/guest-network-card.tsx
+++ b/frontend/src/pages/wifi/guest-network-card.tsx
@@ -62,7 +62,7 @@ export function GuestNetworkCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Guest Network</CardTitle>
+        <CardTitle>Guest Network</CardTitle>
         <ShieldCheck className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
+++ b/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
@@ -5,6 +5,7 @@ import {
   type UseFormRegister,
   type UseFormSetValue,
 } from 'react-hook-form';
+import { CardInset } from '@/components/ui/card-inset';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -32,13 +33,9 @@ export function GuestWifiEnabledFields({
   setValue,
 }: GuestWifiEnabledFieldsProps) {
   return (
-    <div className="space-y-3 rounded-lg border p-4">
+    <CardInset className="space-y-3 p-4">
       <div className="space-y-2">
-        <Label
-          htmlFor="guest-ssid"
-        >
-          SSID
-        </Label>
+        <Label htmlFor="guest-ssid">SSID</Label>
         <Input
           id="guest-ssid"
           placeholder="Guest network name"
@@ -53,11 +50,7 @@ export function GuestWifiEnabledFields({
         ) : null}
       </div>
       <div className="space-y-2">
-        <Label
-          htmlFor="guest-encryption"
-        >
-          Encryption
-        </Label>
+        <Label htmlFor="guest-encryption">Encryption</Label>
         <Controller
           name="encryption"
           control={control}
@@ -86,11 +79,7 @@ export function GuestWifiEnabledFields({
       </div>
       {encryption !== 'none' && (
         <div className="space-y-2">
-          <Label
-            htmlFor="guest-key"
-          >
-            Password
-          </Label>
+          <Label htmlFor="guest-key">Password</Label>
           <Input
             id="guest-key"
             type="password"
@@ -110,6 +99,6 @@ export function GuestWifiEnabledFields({
         Client isolation is enabled — guests cannot see each other. Internet access only, no LAN
         access.
       </p>
-    </div>
+    </CardInset>
   );
 }

--- a/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
+++ b/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
@@ -106,7 +106,7 @@ export function GuestWifiEnabledFields({
           ) : null}
         </div>
       )}
-      <p className="text-xs text-gray-500">
+      <p className="text-xs text-gray-500 dark:text-gray-400">
         Client isolation is enabled — guests cannot see each other. Internet access only, no LAN
         access.
       </p>

--- a/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
+++ b/frontend/src/pages/wifi/guest-wifi-enabled-fields.tsx
@@ -6,6 +6,7 @@ import {
   type UseFormSetValue,
 } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -33,12 +34,11 @@ export function GuestWifiEnabledFields({
   return (
     <div className="space-y-3 rounded-lg border p-4">
       <div className="space-y-2">
-        <label
+        <Label
           htmlFor="guest-ssid"
-          className="text-xs font-medium text-gray-600 dark:text-gray-400"
         >
           SSID
-        </label>
+        </Label>
         <Input
           id="guest-ssid"
           placeholder="Guest network name"
@@ -53,12 +53,11 @@ export function GuestWifiEnabledFields({
         ) : null}
       </div>
       <div className="space-y-2">
-        <label
+        <Label
           htmlFor="guest-encryption"
-          className="text-xs font-medium text-gray-600 dark:text-gray-400"
         >
           Encryption
-        </label>
+        </Label>
         <Controller
           name="encryption"
           control={control}
@@ -87,12 +86,11 @@ export function GuestWifiEnabledFields({
       </div>
       {encryption !== 'none' && (
         <div className="space-y-2">
-          <label
+          <Label
             htmlFor="guest-key"
-            className="text-xs font-medium text-gray-600 dark:text-gray-400"
           >
             Password
-          </label>
+          </Label>
           <Input
             id="guest-key"
             type="password"

--- a/frontend/src/pages/wifi/mac-address-card.tsx
+++ b/frontend/src/pages/wifi/mac-address-card.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { useMACAddresses, useSetMAC, useRandomizeMAC } from '@/hooks/use-wifi';
 import { macCloneFormSchema, type MacCloneFormValues } from '@/lib/schemas/wifi-forms';
 import { MacAddressCloneBlock } from './mac-address-clone-block';
@@ -47,7 +48,7 @@ export function MACAddressCard() {
             <Skeleton className="h-10 w-full" />
           </div>
         ) : !macAddresses || macAddresses.length === 0 ? (
-          <p className="text-sm text-gray-500">No STA interface detected</p>
+          <EmptyState message="No STA interface detected" />
         ) : (
           <form onSubmit={handleSubmit(onApply)} className="space-y-4" noValidate>
             {macAddresses.map((mac) => (

--- a/frontend/src/pages/wifi/mac-address-card.tsx
+++ b/frontend/src/pages/wifi/mac-address-card.tsx
@@ -38,7 +38,7 @@ export function MACAddressCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium">MAC Address Cloning</CardTitle>
+        <CardTitle>MAC Address Cloning</CardTitle>
       </CardHeader>
       <CardContent>
         {macLoading ? (

--- a/frontend/src/pages/wifi/mac-address-clone-block.tsx
+++ b/frontend/src/pages/wifi/mac-address-clone-block.tsx
@@ -3,6 +3,7 @@ import { Shuffle, RotateCcw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type { MacCloneFormValues } from '@/lib/schemas/wifi-forms';
 
 export type MacAddressRow = {
@@ -60,9 +61,9 @@ export function MacAddressCloneBlock({
         </div>
       )}
       <div className="space-y-2">
-        <label htmlFor="mac-input" className="text-xs font-medium text-gray-600 dark:text-gray-400">
+        <Label htmlFor="mac-input">
           Custom MAC Address
-        </label>
+        </Label>
         <Input
           id="mac-input"
           placeholder="AA:BB:CC:DD:EE:FF"

--- a/frontend/src/pages/wifi/mac-address-clone-block.tsx
+++ b/frontend/src/pages/wifi/mac-address-clone-block.tsx
@@ -79,13 +79,12 @@ export function MacAddressCloneBlock({
         ) : null}
       </div>
       <div className="flex flex-wrap gap-2">
-        <Button type="button" size="sm" onClick={onRandomLocal}>
+        <Button type="button" onClick={onRandomLocal}>
           <Shuffle className="mr-1 h-4 w-4" />
           Random
         </Button>
         <Button
           type="button"
-          size="sm"
           variant="outline"
           disabled={randomizePending}
           onClick={onRandomizeApply}
@@ -93,16 +92,10 @@ export function MacAddressCloneBlock({
           <Shuffle className="mr-1 h-4 w-4" />
           {randomizePending ? 'Randomizing...' : 'Randomize & Apply'}
         </Button>
-        <Button type="submit" size="sm" disabled={setMacPending}>
+        <Button type="submit" disabled={setMacPending}>
           {setMacPending ? 'Applying...' : 'Apply'}
         </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={setMacPending}
-          onClick={onResetDefault}
-        >
+        <Button type="button" variant="outline" disabled={setMacPending} onClick={onResetDefault}>
           <RotateCcw className="mr-1 h-4 w-4" />
           Reset to Default
         </Button>

--- a/frontend/src/pages/wifi/mac-policy-add-form.tsx
+++ b/frontend/src/pages/wifi/mac-policy-add-form.tsx
@@ -61,7 +61,6 @@ export function MACPolicyAddForm({ onValidSubmit, isPending }: MACPolicyAddFormP
           </div>
           <Button
             type="submit"
-            size="sm"
             disabled={isPending}
             className="gap-1.5 shrink-0 sm:self-start"
           >

--- a/frontend/src/pages/wifi/mac-policy-add-form.tsx
+++ b/frontend/src/pages/wifi/mac-policy-add-form.tsx
@@ -2,6 +2,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { CardInset } from '@/components/ui/card-inset';
 import { Input } from '@/components/ui/input';
 import { macPolicyAddFormSchema, type MacPolicyAddFormValues } from '@/lib/schemas/wifi-forms';
 
@@ -25,49 +26,50 @@ export function MACPolicyAddForm({ onValidSubmit, isPending }: MACPolicyAddFormP
   return (
     <form
       onSubmit={handleSubmit((data) => onValidSubmit(data, () => reset({ ssid: '', mac: '' })))}
-      className="space-y-2 rounded-md border p-3"
       noValidate
     >
-      <p className="text-xs font-medium text-gray-600 dark:text-gray-400">Add policy</p>
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
-        <div className="flex flex-1 flex-col gap-0.5">
-          <Input
-            placeholder="SSID"
-            aria-invalid={errors.ssid ? 'true' : undefined}
-            aria-describedby={errors.ssid ? 'mac-policy-ssid-err' : undefined}
-            className="flex-1"
-            {...register('ssid')}
-          />
-          {errors.ssid ? (
-            <span id="mac-policy-ssid-err" className="text-xs text-red-500" role="alert">
-              {errors.ssid.message}
-            </span>
-          ) : null}
+      <CardInset className="space-y-2">
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-400">Add policy</p>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Input
+              placeholder="SSID"
+              aria-invalid={errors.ssid ? 'true' : undefined}
+              aria-describedby={errors.ssid ? 'mac-policy-ssid-err' : undefined}
+              className="flex-1"
+              {...register('ssid')}
+            />
+            {errors.ssid ? (
+              <span id="mac-policy-ssid-err" className="text-xs text-red-500" role="alert">
+                {errors.ssid.message}
+              </span>
+            ) : null}
+          </div>
+          <div className="flex flex-1 flex-col gap-0.5">
+            <Input
+              placeholder="MAC (aa:bb:cc:dd:ee:ff)"
+              className="font-mono"
+              aria-invalid={errors.mac ? 'true' : undefined}
+              aria-describedby={errors.mac ? 'mac-policy-mac-err' : undefined}
+              {...register('mac')}
+            />
+            {errors.mac ? (
+              <span id="mac-policy-mac-err" className="text-xs text-red-500" role="alert">
+                {errors.mac.message}
+              </span>
+            ) : null}
+          </div>
+          <Button
+            type="submit"
+            size="sm"
+            disabled={isPending}
+            className="gap-1.5 shrink-0 sm:self-start"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add
+          </Button>
         </div>
-        <div className="flex flex-1 flex-col gap-0.5">
-          <Input
-            placeholder="MAC (aa:bb:cc:dd:ee:ff)"
-            className="font-mono"
-            aria-invalid={errors.mac ? 'true' : undefined}
-            aria-describedby={errors.mac ? 'mac-policy-mac-err' : undefined}
-            {...register('mac')}
-          />
-          {errors.mac ? (
-            <span id="mac-policy-mac-err" className="text-xs text-red-500" role="alert">
-              {errors.mac.message}
-            </span>
-          ) : null}
-        </div>
-        <Button
-          type="submit"
-          size="sm"
-          disabled={isPending}
-          className="gap-1.5 shrink-0 sm:self-start"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          Add
-        </Button>
-      </div>
+      </CardInset>
     </form>
   );
 }

--- a/frontend/src/pages/wifi/mac-policy-card.tsx
+++ b/frontend/src/pages/wifi/mac-policy-card.tsx
@@ -1,5 +1,6 @@
 import { Fingerprint } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useMACPolicies, useSetMACPolicies } from '@/hooks/use-wifi';
 import type { MACPolicy } from '@shared/index';
 import type { MacPolicyAddFormValues } from '@/lib/schemas/wifi-forms';
@@ -30,7 +31,7 @@ export function MACPolicyCard() {
           <Fingerprint className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
-          <div className="h-16 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          <Skeleton className="h-16 w-full" />
         </CardContent>
       </Card>
     );

--- a/frontend/src/pages/wifi/mac-policy-card.tsx
+++ b/frontend/src/pages/wifi/mac-policy-card.tsx
@@ -26,7 +26,7 @@ export function MACPolicyCard() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Per-network MAC Policy</CardTitle>
+          <CardTitle>Per-network MAC Policy</CardTitle>
           <Fingerprint className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
@@ -39,7 +39,7 @@ export function MACPolicyCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Per-network MAC Policy</CardTitle>
+        <CardTitle>Per-network MAC Policy</CardTitle>
         <Fingerprint className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">

--- a/frontend/src/pages/wifi/mac-policy-card.tsx
+++ b/frontend/src/pages/wifi/mac-policy-card.tsx
@@ -28,7 +28,7 @@ export function MACPolicyCard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>Per-network MAC Policy</CardTitle>
-          <Fingerprint className="h-4 w-4 text-gray-400" />
+          <Fingerprint className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <Skeleton className="h-16 w-full" />
@@ -41,7 +41,7 @@ export function MACPolicyCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Per-network MAC Policy</CardTitle>
-        <Fingerprint className="h-4 w-4 text-gray-400" />
+        <Fingerprint className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/pages/wifi/mac-policy-card.tsx
+++ b/frontend/src/pages/wifi/mac-policy-card.tsx
@@ -44,7 +44,7 @@ export function MACPolicyCard() {
         <Fingerprint className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
           Remember which MAC address to use when connecting to specific SSIDs.
         </p>
 

--- a/frontend/src/pages/wifi/mac-policy-table.tsx
+++ b/frontend/src/pages/wifi/mac-policy-table.tsx
@@ -17,7 +17,7 @@ export function MACPolicyTable({ policies, onDelete, isPending }: MACPolicyTable
   return (
     <table className="w-full text-sm">
       <thead>
-        <tr className="border-b text-xs text-gray-500">
+        <tr className="border-b text-xs text-gray-500 dark:text-gray-400">
           <th className="pb-1 text-left font-medium">SSID</th>
           <th className="pb-1 text-left font-medium">MAC Address</th>
           <th className="pb-1" />

--- a/frontend/src/pages/wifi/mac-policy-table.tsx
+++ b/frontend/src/pages/wifi/mac-policy-table.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
 import type { MACPolicy } from '@shared/index';
 
 type MACPolicyTableProps = {
@@ -10,7 +11,7 @@ type MACPolicyTableProps = {
 
 export function MACPolicyTable({ policies, onDelete, isPending }: MACPolicyTableProps) {
   if (policies.length === 0) {
-    return <p className="text-xs text-gray-400">No policies configured.</p>;
+    return <EmptyState message="No policies configured." />;
   }
 
   return (

--- a/frontend/src/pages/wifi/repeater-radio-layout-card.tsx
+++ b/frontend/src/pages/wifi/repeater-radio-layout-card.tsx
@@ -14,7 +14,7 @@ export function RepeaterRadioLayoutCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium">Repeater radio layout</CardTitle>
+        <CardTitle>Repeater radio layout</CardTitle>
         <CardDescription>
           Re-apply the default separation: Wi‑Fi uplink (STA) on one radio, downlink access point on
           the other (when both radios are available and “Wi‑Fi on uplink radio” is off). Use this if

--- a/frontend/src/pages/wifi/wifi-current-connection-card.tsx
+++ b/frontend/src/pages/wifi/wifi-current-connection-card.tsx
@@ -17,7 +17,7 @@ export function WifiCurrentConnectionCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Current Connection</CardTitle>
+        <CardTitle>Current Connection</CardTitle>
         {connection?.connected ? (
           <Wifi className="h-4 w-4 text-green-500" />
         ) : (

--- a/frontend/src/pages/wifi/wifi-current-connection-card.tsx
+++ b/frontend/src/pages/wifi/wifi-current-connection-card.tsx
@@ -15,7 +15,7 @@ export function WifiCurrentConnectionCard() {
   const disconnectMutation = useWifiDisconnect();
 
   return (
-    <Card>
+    <Card className="flex h-full min-w-0 flex-col">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Current Connection</CardTitle>
         {connection?.connected ? (
@@ -24,7 +24,7 @@ export function WifiCurrentConnectionCard() {
           <WifiOff className="h-4 w-4 text-gray-400" />
         )}
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex flex-1 flex-col">
         {connectionLoading ? (
           <div className="space-y-2">
             <Skeleton className="h-4 w-3/4" />
@@ -48,7 +48,7 @@ export function WifiCurrentConnectionCard() {
               <span>IP: {connection.ip_address}</span>
               <SecurityBadge encryption={connection.encryption} />
             </div>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -64,7 +64,7 @@ export function WifiCurrentConnectionCard() {
         ) : (
           <div className="space-y-3">
             <EmptyState message="Not connected to any WiFi network" />
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <WifiScanDialog />
               <WifiHiddenNetworkDialog />
             </div>

--- a/frontend/src/pages/wifi/wifi-hidden-network-dialog-fields.tsx
+++ b/frontend/src/pages/wifi/wifi-hidden-network-dialog-fields.tsx
@@ -1,6 +1,7 @@
 import { Eye, EyeOff } from 'lucide-react';
 import { Controller, type Control, type FieldErrors, type UseFormRegister } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -50,12 +51,12 @@ export function WifiHiddenNetworkDialogFields({
       ) : null}
 
       <div className="space-y-1.5">
-        <label
+        <Label
           htmlFor="hidden-encryption"
           className="text-sm font-medium text-gray-700 dark:text-gray-300"
         >
           Encryption
-        </label>
+        </Label>
         <Controller
           control={control}
           name="encryption"

--- a/frontend/src/pages/wifi/wifi-hidden-network-dialog.tsx
+++ b/frontend/src/pages/wifi/wifi-hidden-network-dialog.tsx
@@ -74,9 +74,15 @@ export function WifiHiddenNetworkDialog() {
 
   return (
     <>
-      <Button onClick={handleOpen} size="sm" variant="outline">
+      <Button
+        onClick={handleOpen}
+        size="sm"
+        variant="outline"
+        aria-label="Hidden network"
+        title="Hidden network"
+      >
         <WifiOff className="mr-1.5 h-3.5 w-3.5" />
-        Hidden Network
+        Hidden
       </Button>
 
       <Dialog

--- a/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
+++ b/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
@@ -41,7 +41,7 @@ export function WifiRadioHardwareCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>Radio Hardware</CardTitle>
-        <Cpu className="h-4 w-4 text-gray-400" />
+        <Cpu className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         {radiosLoading ? (

--- a/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
+++ b/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Cpu, Radio } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { CardInset } from '@/components/ui/card-inset';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -66,9 +67,9 @@ export function WifiRadioHardwareCard() {
                 radio.band === '5g' ? 'ap' : radio.band === '2g' ? 'sta' : null;
               const isRecommended = recommendedRole && radio.role === recommendedRole;
               return (
-                <div
+                <CardInset
                   key={radio.name}
-                  className="flex items-center justify-between gap-3 rounded-lg border p-3"
+                  className="flex items-center justify-between gap-3"
                 >
                   <div className="flex min-w-0 items-center gap-3">
                     <Radio className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
@@ -78,9 +79,7 @@ export function WifiRadioHardwareCard() {
                           {radio.name}
                         </p>
                         {isRecommended && (
-                          <Badge className="bg-green-100 text-xs text-green-800 dark:bg-green-900 dark:text-green-200">
-                            Recommended
-                          </Badge>
+                          <Badge variant="success">Recommended</Badge>
                         )}
 
                         {pendingDisable && (
@@ -119,7 +118,7 @@ export function WifiRadioHardwareCard() {
                       <SelectItem value="none">Disabled</SelectItem>
                     </SelectContent>
                   </Select>
-                </div>
+                </CardInset>
               );
             })}
           </div>

--- a/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
+++ b/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
@@ -40,7 +40,7 @@ export function WifiRadioHardwareCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">Radio Hardware</CardTitle>
+        <CardTitle>Radio Hardware</CardTitle>
         <Cpu className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
+++ b/frontend/src/pages/wifi/wifi-radio-hardware-card.tsx
@@ -71,7 +71,7 @@ export function WifiRadioHardwareCard() {
                   className="flex items-center justify-between gap-3 rounded-lg border p-3"
                 >
                   <div className="flex min-w-0 items-center gap-3">
-                    <Radio className="h-4 w-4 shrink-0 text-gray-500" />
+                    <Radio className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <p className="text-sm font-medium text-gray-900 dark:text-white">
@@ -96,7 +96,7 @@ export function WifiRadioHardwareCard() {
                           {radio.disabled ? 'Disabled' : 'Active'}
                         </Badge>
                       </div>
-                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500">
+                      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
                         <span>{bandLabel}</span>
                         <span>Ch {radio.channel}</span>
                         <span>{radio.htmode}</span>

--- a/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
+++ b/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
@@ -63,7 +63,7 @@ export function WifiSavedNetworksCard() {
     <Card className="min-w-0">
       <CardHeader className="space-y-1">
         <div className="flex items-center gap-2">
-          <CardTitle className="text-sm font-medium">Saved networks</CardTitle>
+          <CardTitle>Saved networks</CardTitle>
           <InfoTooltip text={SAVED_LIST_TOOLTIP} />
         </div>
         <CardDescription>

--- a/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
+++ b/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
@@ -118,7 +118,7 @@ export function WifiSavedNetworksCard() {
               return (
               <li
                 key={network.section}
-                className="flex flex-col gap-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-1"
+                className="flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-4"
               >
                 <div className="flex min-w-0 items-center gap-3">
                   <Wifi className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />

--- a/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
+++ b/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
@@ -7,6 +7,7 @@ import {
   CardDescription,
   CardContent,
 } from '@/components/ui/card';
+import { CardInset } from '@/components/ui/card-inset';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -60,7 +61,7 @@ export function WifiSavedNetworksCard() {
   const isRiskyDelete = pendingDelete && savedNetworks.length === 1 && !autoReconnect?.enabled;
 
   return (
-    <Card className="min-w-0">
+    <Card className="flex h-full min-w-0 flex-col">
       <CardHeader className="space-y-1">
         <div className="flex items-center gap-2">
           <CardTitle>Saved networks</CardTitle>
@@ -71,8 +72,11 @@ export function WifiSavedNetworksCard() {
           the stored password. Arrows set priority for automatic selection (see info).
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-gray-800/30">
+      <CardContent className="flex flex-1 flex-col space-y-4">
+        <CardInset
+          variant="muted"
+          className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        >
           <div className="min-w-0 space-y-0.5 pr-2">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">Auto-reconnect</span>
@@ -90,7 +94,7 @@ export function WifiSavedNetworksCard() {
             disabled={setAutoReconnect.isPending}
             className="shrink-0 sm:ml-auto"
           />
-        </div>
+        </CardInset>
 
         {savedLoading ? (
           <div className="space-y-2">

--- a/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
+++ b/frontend/src/pages/wifi/wifi-saved-networks-card.tsx
@@ -67,20 +67,18 @@ export function WifiSavedNetworksCard() {
           <InfoTooltip text={SAVED_LIST_TOOLTIP} />
         </div>
         <CardDescription>
-          <span className="text-muted-foreground">
-            In use = enabled profile; standby = saved but not active. <strong>Connect</strong> uses
-            the stored password. Arrows set priority for automatic selection (see info).
-          </span>
+          In use = enabled profile; standby = saved but not active. <strong>Connect</strong> uses
+          the stored password. Arrows set priority for automatic selection (see info).
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-muted/15">
+        <div className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-white/10 dark:bg-gray-800/30">
           <div className="min-w-0 space-y-0.5 pr-2">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">Auto-reconnect</span>
               <InfoTooltip text={AUTO_RECONNECT_HELP} />
             </div>
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               Retry Wi‑Fi when the link drops (active profile only).
             </p>
           </div>
@@ -103,7 +101,7 @@ export function WifiSavedNetworksCard() {
           <EmptyState message="No saved networks" />
         ) : (
           <ul
-            className="divide-y divide-border rounded-lg border border-border dark:divide-white/10 dark:border-white/10"
+            className="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-white/10 dark:border-white/10"
             role="list"
           >
             {savedNetworks.map((network, index) => {
@@ -119,7 +117,7 @@ export function WifiSavedNetworksCard() {
                 className="flex flex-col gap-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4 sm:px-1"
               >
                 <div className="flex min-w-0 items-center gap-3">
-                  <Wifi className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <Wifi className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
                   <div className="min-w-0">
                     <p className="truncate text-sm font-medium">{network.ssid}</p>
                     <SecurityBadge encryption={network.encryption} />
@@ -213,7 +211,7 @@ export function WifiSavedNetworksCard() {
               <DialogTitle>Remove saved network</DialogTitle>
               <DialogDescription>
                 Are you sure you want to remove the saved network{' '}
-                <span className="font-medium text-foreground">"{pendingDelete?.ssid}"</span>?
+                <span className="font-medium">"{pendingDelete?.ssid}"</span>?
               </DialogDescription>
             </DialogHeader>
 

--- a/frontend/src/pages/wifi/wifi-scan-dialog.tsx
+++ b/frontend/src/pages/wifi/wifi-scan-dialog.tsx
@@ -45,9 +45,11 @@ export function WifiScanDialog() {
           void refetch();
         }}
         size="sm"
+        aria-label="Scan networks"
+        title="Scan networks"
       >
         <Search className="mr-1.5 h-3.5 w-3.5" />
-        Scan Networks
+        Scan
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>

--- a/frontend/src/pages/wifi/wifi-scan-list.tsx
+++ b/frontend/src/pages/wifi/wifi-scan-list.tsx
@@ -4,6 +4,7 @@ import type { WifiScanResult, GroupedScanNetwork } from '@shared/index';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/components/ui/empty-state';
 import { SignalStrengthIcon } from '@/components/wifi/signal-strength-icon';
 import { SecurityBadge } from '@/components/wifi/security-badge';
 import { formatWifiBandLabel, normalizeWifiBandKey } from '@/lib/wifi-band';
@@ -48,7 +49,7 @@ export function WifiScanList({
           ))}
         </div>
       ) : groups.length === 0 ? (
-        <p className="py-4 text-center text-sm text-gray-500">No networks found</p>
+        <EmptyState message="No networks found" />
       ) : (
         <ul className="divide-y divide-gray-200 dark:divide-gray-800" role="list">
           {groups.map((group) => {

--- a/frontend/src/pages/wifi/wifi-scan-list.tsx
+++ b/frontend/src/pages/wifi/wifi-scan-list.tsx
@@ -97,7 +97,7 @@ export function WifiScanList({
                   <>
                     <button
                       type="button"
-                      className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
+                      className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
                       onClick={() => setExpandedKey(isExpanded ? null : listKey)}
                       aria-expanded={isExpanded}
                     >

--- a/frontend/src/pages/wifi/wifi-schedule-card.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-card.tsx
@@ -54,7 +54,7 @@ export function WiFiScheduleCard() {
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle>WiFi Schedule</CardTitle>
-          <Clock className="h-4 w-4 text-gray-400" />
+          <Clock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         </CardHeader>
         <CardContent>
           <Skeleton className="h-16 w-full" />
@@ -67,7 +67,7 @@ export function WiFiScheduleCard() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle>WiFi Schedule</CardTitle>
-        <Clock className="h-4 w-4 text-gray-400" />
+        <Clock className="h-4 w-4 text-gray-500 dark:text-gray-400" />
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(onSave)} className="space-y-4" noValidate>

--- a/frontend/src/pages/wifi/wifi-schedule-card.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-card.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { Clock } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useWiFiSchedule, useSetWiFiSchedule } from '@/hooks/use-wifi';
 import { wifiScheduleFormSchema, type WifiScheduleFormValues } from '@/lib/schemas/wifi-forms';
 import { WiFiScheduleFormFields } from '@/pages/wifi/wifi-schedule-form-fields';
@@ -56,7 +57,7 @@ export function WiFiScheduleCard() {
           <Clock className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
-          <div className="h-16 animate-pulse rounded bg-gray-100 dark:bg-gray-800" />
+          <Skeleton className="h-16 w-full" />
         </CardContent>
       </Card>
     );

--- a/frontend/src/pages/wifi/wifi-schedule-card.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-card.tsx
@@ -52,7 +52,7 @@ export function WiFiScheduleCard() {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">WiFi Schedule</CardTitle>
+          <CardTitle>WiFi Schedule</CardTitle>
           <Clock className="h-4 w-4 text-gray-400" />
         </CardHeader>
         <CardContent>
@@ -65,7 +65,7 @@ export function WiFiScheduleCard() {
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-        <CardTitle className="text-sm font-medium">WiFi Schedule</CardTitle>
+        <CardTitle>WiFi Schedule</CardTitle>
         <Clock className="h-4 w-4 text-gray-400" />
       </CardHeader>
       <CardContent>

--- a/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
@@ -22,7 +22,7 @@ export function WiFiScheduleFormFields({
       <div className="flex items-center justify-between">
         <div className="space-y-0.5">
           <p className="text-sm">Enable schedule</p>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
             Automatically turn WiFi on and off at set times (cron-based)
           </p>
         </div>

--- a/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
@@ -1,4 +1,5 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { CardInset } from '@/components/ui/card-inset';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -35,7 +36,7 @@ export function WiFiScheduleFormFields({
       </div>
 
       {enabled && (
-        <div className="space-y-3 rounded-md border p-3">
+        <CardInset className="space-y-3">
           <div className="flex flex-wrap items-center gap-3">
             <Label
               className="w-16 shrink-0 text-sm text-gray-600 dark:text-gray-400"
@@ -82,7 +83,7 @@ export function WiFiScheduleFormFields({
               ) : null}
             </div>
           </div>
-        </div>
+        </CardInset>
       )}
     </>
   );

--- a/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
+++ b/frontend/src/pages/wifi/wifi-schedule-form-fields.tsx
@@ -1,6 +1,7 @@
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import type { WifiScheduleFormValues } from '@/lib/schemas/wifi-forms';
 
 type WiFiScheduleFormFieldsProps = {
@@ -36,12 +37,12 @@ export function WiFiScheduleFormFields({
       {enabled && (
         <div className="space-y-3 rounded-md border p-3">
           <div className="flex flex-wrap items-center gap-3">
-            <label
+            <Label
               className="w-16 shrink-0 text-sm text-gray-600 dark:text-gray-400"
               htmlFor="wifi-on-time"
             >
               On at
-            </label>
+            </Label>
             <div className="flex flex-col gap-0.5">
               <Input
                 id="wifi-on-time"
@@ -59,12 +60,12 @@ export function WiFiScheduleFormFields({
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-3">
-            <label
+            <Label
               className="w-16 shrink-0 text-sm text-gray-600 dark:text-gray-400"
               htmlFor="wifi-off-time"
             >
               Off at
-            </label>
+            </Label>
             <div className="flex flex-col gap-0.5">
               <Input
                 id="wifi-off-time"

--- a/frontend/src/pages/wifi/wifi-wireless-panel.tsx
+++ b/frontend/src/pages/wifi/wifi-wireless-panel.tsx
@@ -19,7 +19,7 @@ export function WifiWirelessPanel({ panelId, tabId, hidden }: WifiWirelessPanelP
   const isPureSTA = currentMode === 'client';
 
   return (
-    <div id={panelId} role="tabpanel" aria-labelledby={tabId} hidden={hidden} className="space-y-4 sm:space-y-6">
+    <div id={panelId} role="tabpanel" aria-labelledby={tabId} hidden={hidden} className="space-y-6">
       <WifiHealthBanner />
       {!isPureAP && <CaptivePortalCard />}
       <WifiModeCard />

--- a/frontend/src/pages/wifi/wifi-wireless-panel.tsx
+++ b/frontend/src/pages/wifi/wifi-wireless-panel.tsx
@@ -25,11 +25,11 @@ export function WifiWirelessPanel({ panelId, tabId, hidden }: WifiWirelessPanelP
       <WifiModeCard />
 
       {!isPureAP && (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-3 md:gap-6 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
-          <div className="min-w-0 md:col-span-1 lg:col-span-2 xl:col-span-2 2xl:col-span-2">
+        <div className="grid grid-cols-1 items-stretch gap-4 md:grid-cols-3 md:gap-6 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
+          <div className="min-w-0 h-full md:col-span-1 lg:col-span-2 xl:col-span-2 2xl:col-span-2">
             <WifiCurrentConnectionCard />
           </div>
-          <div className="min-w-0 md:col-span-2 lg:col-span-3 xl:col-span-4 2xl:col-span-5">
+          <div className="min-w-0 h-full md:col-span-2 lg:col-span-3 xl:col-span-4 2xl:col-span-5">
             <WifiSavedNetworksCard />
           </div>
         </div>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -58,6 +58,7 @@ const protectedRoute = createRoute({
   beforeLoad: requireSetupComplete,
 });
 
+/** Shell header title. Service children use `Services / X`; WiFi/Network sub-routes stay flat. */
 function shellPage(title: string, PageComponent: ComponentType) {
   return () => (
     <AppShell title={title}>


### PR DESCRIPTION
## Summary
- Unify card chrome: `CardTitle` default is `text-sm font-medium`; cleaned ~70 redundant overrides so cards match board-wide
- Add shared `Label` + `InlineError` primitives; migrate dense form labels and load/display errors
- Normalize page shell spacing (Clients double-pad, LazyBoundary pad, SQM `space-y-6`)
- Standardize loading → `Skeleton`, empties → `EmptyState`; fix dashboard SourceCard / Quick status light-mode contrast
- Theme sweep: secondary `text-gray-500` + `dark:text-gray-400`; drop undefined shadcn-ish tokens
- Docs: plan + `ui-theming.md` contracts; plans index updated

## Test plan
- [x] `make lint`
- [x] `make test` (backend + shared + frontend 262)
- [x] `make build`
- [ ] Spot-check light + dark: Dashboard SourceCards, Clients, WiFi/Network tabs, System forms, Login
- [ ] Confirm card titles look same size across VPN / Services / System / Logs